### PR TITLE
Migrate Email Connector to JDK 11

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Set version env variable
         run: echo ::set-env name=VERSION::$((grep -w "version" | cut -d= -f2) < gradle.properties | cut -d- -f1)
       - name : Pre release depenency version update

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ For example demonstrations of the usage, go to [Ballerina By Examples](https://b
 
 ### Setting Up the Prerequisites
 
-1. Download and install Java SE Development Kit (JDK) version 8 (from one of the following locations).
+1. Download and install Java SE Development Kit (JDK) version 11 (from one of the following locations).
 
-   * [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
+   * [Oracle](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
 
-   * [OpenJDK](http://openjdk.java.net/install/index.html)
+   * [OpenJDK](https://adoptopenjdk.net/)
 
         > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
      

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ ext.testngVersion = "6.14.3"
 ext.slf4jVersion = "1.7.30"
 ext.javaMailVersion = "1.6.2"
 ext.greenmailVersion = "1.5.11"
+//ext.jakartaActivationVersion = "1.2.2"
 ext.mimepullVersion= "1.9.11"
 
 allprojects {
@@ -69,9 +70,13 @@ allprojects {
             }
         }
 
-        maven {
-            url = 'https://mvnrepository.com/artifact/com.icegreen/greenmail'
-        }
+//        maven {
+//            url = 'https://mvnrepository.com/artifact/com.icegreen/greenmail'
+//        }
+
+//        maven {
+//            url = 'https://mvnrepository.com/artifact/com.sun.activation/javax.activation'
+//        }
 
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-task'
@@ -163,13 +168,14 @@ subprojects {
         ballerinaStdLibs
     }
     dependencies {
-        compile group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
-        compile group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
-
-        compile group: 'com.sun.mail', name: 'javax.mail', version: "${javaMailVersion}"
-        compile group: 'com.icegreen', name: 'greenmail', version: "${greenmailVersion}"
-        compile group: 'org.testng', name: 'testng', version: "${testngVersion}"
-        compile group: 'org.jvnet.mimepull', name: 'mimepull', version: "${mimepullVersion}"
+//        compile group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+//        compile group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
+//
+//        compile group: 'com.sun.mail', name: 'javax.mail', version: "${javaMailVersion}"
+//        compile group: 'com.icegreen', name: 'greenmail', version: "${greenmailVersion}"
+//        compile group: 'com.sun.activation', name: 'jakarta.activation', version: "${jakartaActivationVersion}"
+//        compile group: 'org.testng', name: 'testng', version: "${testngVersion}"
+//        compile group: 'org.jvnet.mimepull', name: 'mimepull', version: "${mimepullVersion}"
 
         /* Standard libraries */
         ballerinaStdLibs "org.ballerinalang:task-ballerina:${stdlibTaskVersion}"
@@ -183,18 +189,21 @@ subprojects {
         ballerinaStdLibs "org.ballerinalang:config-ballerina:${stdlibConfigVersion}"
         ballerinaStdLibs "org.ballerinalang:io-ballerina:${stdlibIoVersion}"
 
-        externalJars(group: 'com.sun.mail', name: 'javax.mail', version: "${javaMailVersion}") {
-            transitive = false
-        }
-        externalJars(group: 'com.icegreen', name: 'greenmail', version: "${greenmailVersion}") {
-            transitive = false
-        }
-        externalJars(group: 'org.testng', name: 'testng', version: "${testngVersion}") {
-            transitive = false
-        }
-        externalJars(group: 'org.jvnet.mimepull', name: 'mimepull', version: "${mimepullVersion}") {
-            transitive = false
-        }
+//        externalJars(group: 'com.sun.mail', name: 'javax.mail', version: "${javaMailVersion}") {
+//            transitive = false
+//        }
+//        externalJars(group: 'com.icegreen', name: 'greenmail', version: "${greenmailVersion}") {
+//            transitive = false
+//        }
+//        externalJars(group: 'com.sun.activation', name: 'jakarta.activation', version: "${jakartaActivationVersion}") {
+//            transitive = false
+//        }
+//        externalJars(group: 'org.testng', name: 'testng', version: "${testngVersion}") {
+//            transitive = false
+//        }
+//        externalJars(group: 'org.jvnet.mimepull', name: 'mimepull', version: "${mimepullVersion}") {
+//            transitive = false
+//        }
 
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ ext.testngVersion = "6.14.3"
 ext.slf4jVersion = "1.7.30"
 ext.javaMailVersion = "1.6.2"
 ext.greenmailVersion = "1.5.11"
-//ext.jakartaActivationVersion = "1.2.2"
 ext.mimepullVersion= "1.9.11"
 
 allprojects {
@@ -69,14 +68,6 @@ allprojects {
                 password System.getenv("packagePAT")
             }
         }
-
-//        maven {
-//            url = 'https://mvnrepository.com/artifact/com.icegreen/greenmail'
-//        }
-
-//        maven {
-//            url = 'https://mvnrepository.com/artifact/com.sun.activation/javax.activation'
-//        }
 
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-task'
@@ -168,14 +159,6 @@ subprojects {
         ballerinaStdLibs
     }
     dependencies {
-//        compile group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
-//        compile group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
-//
-//        compile group: 'com.sun.mail', name: 'javax.mail', version: "${javaMailVersion}"
-//        compile group: 'com.icegreen', name: 'greenmail', version: "${greenmailVersion}"
-//        compile group: 'com.sun.activation', name: 'jakarta.activation', version: "${jakartaActivationVersion}"
-//        compile group: 'org.testng', name: 'testng', version: "${testngVersion}"
-//        compile group: 'org.jvnet.mimepull', name: 'mimepull', version: "${mimepullVersion}"
 
         /* Standard libraries */
         ballerinaStdLibs "org.ballerinalang:task-ballerina:${stdlibTaskVersion}"
@@ -188,22 +171,6 @@ subprojects {
         ballerinaStdLibs "org.ballerinalang:system-ballerina:${stdlibSystemVersion}"
         ballerinaStdLibs "org.ballerinalang:config-ballerina:${stdlibConfigVersion}"
         ballerinaStdLibs "org.ballerinalang:io-ballerina:${stdlibIoVersion}"
-
-//        externalJars(group: 'com.sun.mail', name: 'javax.mail', version: "${javaMailVersion}") {
-//            transitive = false
-//        }
-//        externalJars(group: 'com.icegreen', name: 'greenmail', version: "${greenmailVersion}") {
-//            transitive = false
-//        }
-//        externalJars(group: 'com.sun.activation', name: 'jakarta.activation', version: "${jakartaActivationVersion}") {
-//            transitive = false
-//        }
-//        externalJars(group: 'org.testng', name: 'testng', version: "${testngVersion}") {
-//            transitive = false
-//        }
-//        externalJars(group: 'org.jvnet.mimepull', name: 'mimepull', version: "${mimepullVersion}") {
-//            transitive = false
-//        }
 
     }
 

--- a/email-ballerina/Ballerina.toml
+++ b/email-ballerina/Ballerina.toml
@@ -15,7 +15,7 @@ version = "@toml.version@"
 "ballerina/io" = "@stdlib.io.version@"
 
 [platform]
-target = "java8"
+target = "java11"
 
     [[platform.libraries]]
     artifactId = "java.mail"

--- a/email-ballerina/build.gradle
+++ b/email-ballerina/build.gradle
@@ -171,9 +171,9 @@ task ballerinaTest {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat test --code-coverage --all ${debugParams} && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat test --all ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$distributionBinPath/ballerina test --code-coverage --all ${debugParams}"
+                commandLine 'sh', '-c', "$distributionBinPath/ballerina test --all ${debugParams}"
             }
         }
     }

--- a/email-ballerina/src/email/tests/unit-tests/ImapComplexEmailReceive.bal
+++ b/email-ballerina/src/email/tests/unit-tests/ImapComplexEmailReceive.bal
@@ -124,13 +124,13 @@ function testReceiveComplexEmailImap() {
 }
 
 public function startComplexImapServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ImapComplexEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ImapComplexEmailReceiveTest"
 } external;
 
 public function stopComplexImapServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ImapComplexEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ImapComplexEmailReceiveTest"
 } external;
 
 public function sendEmailComplexImapServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ImapComplexEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ImapComplexEmailReceiveTest"
 } external;

--- a/email-ballerina/src/email/tests/unit-tests/ImapSimpleSecureEmailReceive.bal
+++ b/email-ballerina/src/email/tests/unit-tests/ImapSimpleSecureEmailReceive.bal
@@ -61,13 +61,13 @@ function testReceiveSimpleEmailImap() {
 }
 
 public function startSimpleSecureImapServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ImapSimpleSecureEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ImapSimpleSecureEmailReceiveTest"
 } external;
 
 public function stopSimpleSecureImapServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ImapSimpleSecureEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ImapSimpleSecureEmailReceiveTest"
 } external;
 
 public function sendEmailSimpleSecureImapServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ImapSimpleSecureEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ImapSimpleSecureEmailReceiveTest"
 } external;

--- a/email-ballerina/src/email/tests/unit-tests/ListenerImapReceive.bal
+++ b/email-ballerina/src/email/tests/unit-tests/ListenerImapReceive.bal
@@ -119,13 +119,13 @@ function testListenEmailImap() {
 }
 
 public function startImapListener() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ListenerImapReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ListenerImapReceiveTest"
 } external;
 
 public function stopImapListener() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ListenerImapReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ListenerImapReceiveTest"
 } external;
 
 public function sendEmailImapListener() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ListenerImapReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ListenerImapReceiveTest"
 } external;

--- a/email-ballerina/src/email/tests/unit-tests/ListenerPopReceive.bal
+++ b/email-ballerina/src/email/tests/unit-tests/ListenerPopReceive.bal
@@ -118,13 +118,13 @@ function testListenEmailPop() {
 }
 
 public function startPopListener() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ListenerPopReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ListenerPopReceiveTest"
 } external;
 
 public function stopPopListener() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ListenerPopReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ListenerPopReceiveTest"
 } external;
 
 public function sendEmailPopListener() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/ListenerPopReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.ListenerPopReceiveTest"
 } external;

--- a/email-ballerina/src/email/tests/unit-tests/PopComplexEmailReceive.bal
+++ b/email-ballerina/src/email/tests/unit-tests/PopComplexEmailReceive.bal
@@ -125,13 +125,13 @@ function testReceiveComplexEmailPop() {
 }
 
 public function startComplexPopServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/PopComplexEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.PopComplexEmailReceiveTest"
 } external;
 
 public function stopComplexPopServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/PopComplexEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.PopComplexEmailReceiveTest"
 } external;
 
 public function sendEmailComplexPopServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/PopComplexEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.PopComplexEmailReceiveTest"
 } external;

--- a/email-ballerina/src/email/tests/unit-tests/PopSimpleSecureEmailReceive.bal
+++ b/email-ballerina/src/email/tests/unit-tests/PopSimpleSecureEmailReceive.bal
@@ -62,13 +62,13 @@ function testReceiveSimpleEmailPop() {
 }
 
 public function startSimpleSecurePopServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/PopSimpleSecureEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.PopSimpleSecureEmailReceiveTest"
 } external;
 
 public function stopSimpleSecurePopServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/PopSimpleSecureEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.PopSimpleSecureEmailReceiveTest"
 } external;
 
 public function sendEmailSimpleSecurePopServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/PopSimpleSecureEmailReceiveTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.PopSimpleSecureEmailReceiveTest"
 } external;

--- a/email-ballerina/src/email/tests/unit-tests/SmtpComplexEmailSend.bal
+++ b/email-ballerina/src/email/tests/unit-tests/SmtpComplexEmailSend.bal
@@ -115,13 +115,13 @@ function testSendComplexEmail() {
 }
 
 public function startComplexSmtpServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/SmtpComplexEmailSendTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.SmtpComplexEmailSendTest"
 } external;
 
 public function stopComplexSmtpServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/SmtpComplexEmailSendTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.SmtpComplexEmailSendTest"
 } external;
 
 public function validateComplexEmails() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/SmtpComplexEmailSendTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.SmtpComplexEmailSendTest"
 } external;

--- a/email-ballerina/src/email/tests/unit-tests/SmtpSimpleSecureEmailSend.bal
+++ b/email-ballerina/src/email/tests/unit-tests/SmtpSimpleSecureEmailSend.bal
@@ -68,13 +68,13 @@ function testSendSimpleEmail() {
 }
 
 public function startSimpleSecureSmtpServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/SmtpSimpleSecureEmailSendTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.SmtpSimpleSecureEmailSendTest"
 } external;
 
 public function stopSimpleSecureSmtpServer() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/SmtpSimpleSecureEmailSendTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.SmtpSimpleSecureEmailSendTest"
 } external;
 
 public function validateSimpleSecureEmail() returns Error? = @java:Method {
-    'class: "org/ballerinalang/stdlib/email/testutils/mockServerUtils/SmtpSimpleSecureEmailSendTest"
+    'class: "org.ballerinalang.stdlib.email.testutils.SmtpSimpleSecureEmailSendTest"
 } external;

--- a/email-native/build.gradle
+++ b/email-native/build.gradle
@@ -32,16 +32,10 @@ dependencies {
 
     compile group: 'com.sun.mail', name: 'javax.mail', version: "${javaMailVersion}"
     compile group: 'org.jvnet.mimepull', name: 'mimepull', version: "${mimepullVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-mime', version: "${ballerinaLangVersion}"
 
-    compile group: 'org.ballerinalang', name: 'ballerina-io', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-system', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-file', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-runtime-api', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-task', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-time', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-log-api', version: "${ballerinaLangVersion}"
-    compile group: 'org.ballerinalang', name: 'ballerina-java', version: "${ballerinaLangVersion}"
+    compile group: 'org.ballerinalang', name: 'ballerina-core', version: "${ballerinaLangVersion}"
+    compile group: 'org.ballerinalang', name: 'io-native', version: "${stdlibIoVersion}"
+    compile group: 'org.ballerinalang', name: 'mime-native', version: "${stdlibMimeVersion}"
 
 }
 
@@ -52,3 +46,17 @@ checkstyle {
 }
 
 checkstyleMain.dependsOn(":build-config:checkstyle:downloadMultipleFiles")
+
+def excludePattern = '**/module-info.java'
+tasks.withType(Checkstyle) {
+    exclude excludePattern
+}
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}

--- a/email-native/src/main/java/module-info.java
+++ b/email-native/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module io.ballerina.stdlib.email {
+    exports org.ballerinalang.stdlib.email.util;
+    exports org.ballerinalang.stdlib.email.client;
+    exports org.ballerinalang.stdlib.email.service.compiler;
+    requires io.ballerina.jvm;
+    requires org.slf4j;
+    requires io.ballerina.lang;
+    requires java.mail;
+    requires io.ballerina.stdlib.mime;
+    requires io.ballerina.stdlib.io;
+}

--- a/email-native/src/main/java/module-info.java
+++ b/email-native/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 module io.ballerina.stdlib.email {
     exports org.ballerinalang.stdlib.email.util;
     exports org.ballerinalang.stdlib.email.client;

--- a/email-test-utils/build.gradle
+++ b/email-test-utils/build.gradle
@@ -35,3 +35,11 @@ dependencies {
     compile project(":email-native")
 }
 
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}

--- a/email-test-utils/src/main/java/module-info.java
+++ b/email-test-utils/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 module io.ballerina.stdlib.email.testutils {
     requires org.slf4j;
     requires greenmail;

--- a/email-test-utils/src/main/java/module-info.java
+++ b/email-test-utils/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module io.ballerina.stdlib.email.testutils {
+    requires org.slf4j;
+    requires greenmail;
+    requires io.ballerina.stdlib.mime;
+    requires java.mail;
+    requires io.ballerina.stdlib.email;
+    requires testng;
+    exports org.ballerinalang.stdlib.email.testutils;
+}

--- a/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/ImapComplexEmailReceiveTest.java
+++ b/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/ImapComplexEmailReceiveTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.ballerinalang.stdlib.email.testutils.mockServerUtils;
+package org.ballerinalang.stdlib.email.testutils;
 
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMail;
@@ -35,11 +35,11 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
 /**
- * Test class for email receive using POP3 with all the parameters.
+ * Test class for email receive using IMAP with all the parameters.
  *
  * @since slp4
  */
-public class PopComplexEmailReceiveTest {
+public class ImapComplexEmailReceiveTest {
 
     private static GreenMailUser user;
     private static final String USER_PASSWORD = "abcdef123";
@@ -63,23 +63,23 @@ public class PopComplexEmailReceiveTest {
     private static final String[] EMAIL_REPLY_TO_ADDRESSES = {"reply1@abc.com", "reply2@abc.com"};
     private static GreenMail mailServer;
 
-    public static Object startComplexPopServer() throws MessagingException {
+    public static Object startComplexImapServer() {
         startServer();
         return null;
     }
 
-    public static Object stopComplexPopServer() {
+    public static Object stopComplexImapServer() {
         mailServer.stop();
         return null;
     }
 
-    public static Object sendEmailComplexPopServer() throws MessagingException {
+    public static Object sendEmailComplexImapServer() throws MessagingException {
         sendEmail();
         return null;
     }
 
     private static void startServer() {
-        mailServer = new GreenMail(ServerSetupTest.POP3);
+        mailServer = new GreenMail(ServerSetupTest.IMAP);
         mailServer.start();
         user = mailServer.setUser(EMAIL_USER_ADDRESS, USER_NAME, USER_PASSWORD);
         mailServer.setUser(EMAIL_USER_ADDRESS, USER_NAME, USER_PASSWORD);

--- a/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/ImapSimpleSecureEmailReceiveTest.java
+++ b/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/ImapSimpleSecureEmailReceiveTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.ballerinalang.stdlib.email.testutils.mockServerUtils;
+package org.ballerinalang.stdlib.email.testutils;
 
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.DummySSLSocketFactory;

--- a/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/ListenerImapReceiveTest.java
+++ b/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/ListenerImapReceiveTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.ballerinalang.stdlib.email.testutils.mockServerUtils;
+package org.ballerinalang.stdlib.email.testutils;
 
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.DummySSLSocketFactory;

--- a/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/ListenerPopReceiveTest.java
+++ b/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/ListenerPopReceiveTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.ballerinalang.stdlib.email.testutils.mockServerUtils;
+package org.ballerinalang.stdlib.email.testutils;
 
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.DummySSLSocketFactory;
@@ -32,11 +32,11 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
 /**
- * Test class for email receive using POP3S with least number of parameters.
+ * Test class for email receipt using the listener.
  *
  * @since slp4
  */
-public class PopSimpleSecureEmailReceiveTest {
+public class ListenerPopReceiveTest {
 
     private static GreenMailUser user;
     private static final int PORT_NUMBER = 3995;
@@ -50,18 +50,20 @@ public class PopSimpleSecureEmailReceiveTest {
     private static final int SERVER_TIMEOUT = 5000;
     private static GreenMail mailServer;
 
-    public static Object startSimpleSecurePopServer() {
+    public static Object startPopListener() {
         startServer();
         return null;
     }
 
-    public static Object stopSimpleSecurePopServer() {
+    public static Object stopPopListener() throws InterruptedException {
         mailServer.stop();
+        Thread.sleep(10000);
         return null;
     }
 
-    public static Object sendEmailSimpleSecurePopServer() throws MessagingException {
+    public static Object sendEmailPopListener() throws MessagingException, InterruptedException {
         sendEmail();
+        Thread.sleep(10000);
         return null;
     }
 

--- a/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/PopComplexEmailReceiveTest.java
+++ b/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/PopComplexEmailReceiveTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.ballerinalang.stdlib.email.testutils.mockServerUtils;
+package org.ballerinalang.stdlib.email.testutils;
 
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMail;
@@ -35,11 +35,11 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
 /**
- * Test class for email receive using IMAP with all the parameters.
+ * Test class for email receive using POP3 with all the parameters.
  *
  * @since slp4
  */
-public class ImapComplexEmailReceiveTest {
+public class PopComplexEmailReceiveTest {
 
     private static GreenMailUser user;
     private static final String USER_PASSWORD = "abcdef123";
@@ -63,23 +63,23 @@ public class ImapComplexEmailReceiveTest {
     private static final String[] EMAIL_REPLY_TO_ADDRESSES = {"reply1@abc.com", "reply2@abc.com"};
     private static GreenMail mailServer;
 
-    public static Object startComplexImapServer() {
+    public static Object startComplexPopServer() throws MessagingException {
         startServer();
         return null;
     }
 
-    public static Object stopComplexImapServer() {
+    public static Object stopComplexPopServer() {
         mailServer.stop();
         return null;
     }
 
-    public static Object sendEmailComplexImapServer() throws MessagingException {
+    public static Object sendEmailComplexPopServer() throws MessagingException {
         sendEmail();
         return null;
     }
 
     private static void startServer() {
-        mailServer = new GreenMail(ServerSetupTest.IMAP);
+        mailServer = new GreenMail(ServerSetupTest.POP3);
         mailServer.start();
         user = mailServer.setUser(EMAIL_USER_ADDRESS, USER_NAME, USER_PASSWORD);
         mailServer.setUser(EMAIL_USER_ADDRESS, USER_NAME, USER_PASSWORD);

--- a/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/PopSimpleSecureEmailReceiveTest.java
+++ b/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/PopSimpleSecureEmailReceiveTest.java
@@ -16,27 +16,26 @@
  * under the License.
  */
 
-package org.ballerinalang.stdlib.email.testutils.mockServerUtils;
+package org.ballerinalang.stdlib.email.testutils;
 
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.DummySSLSocketFactory;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
 
-import java.security.Security;
-
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.Session;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
+import java.security.Security;
 
 /**
- * Test class for email receipt using the listener.
+ * Test class for email receive using POP3S with least number of parameters.
  *
  * @since slp4
  */
-public class ListenerPopReceiveTest {
+public class PopSimpleSecureEmailReceiveTest {
 
     private static GreenMailUser user;
     private static final int PORT_NUMBER = 3995;
@@ -50,20 +49,18 @@ public class ListenerPopReceiveTest {
     private static final int SERVER_TIMEOUT = 5000;
     private static GreenMail mailServer;
 
-    public static Object startPopListener() {
+    public static Object startSimpleSecurePopServer() {
         startServer();
         return null;
     }
 
-    public static Object stopPopListener() throws InterruptedException {
+    public static Object stopSimpleSecurePopServer() {
         mailServer.stop();
-        Thread.sleep(10000);
         return null;
     }
 
-    public static Object sendEmailPopListener() throws MessagingException, InterruptedException {
+    public static Object sendEmailSimpleSecurePopServer() throws MessagingException {
         sendEmail();
-        Thread.sleep(10000);
         return null;
     }
 

--- a/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/SmtpComplexEmailSendTest.java
+++ b/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/SmtpComplexEmailSendTest.java
@@ -16,18 +16,11 @@
  * under the License.
  */
 
-package org.ballerinalang.stdlib.email.testutils.mockServerUtils;
+package org.ballerinalang.stdlib.email.testutils;
 
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import org.ballerinalang.stdlib.email.util.CommonUtil;
-
-import java.io.ByteArrayOutputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 import javax.mail.Address;
 import javax.mail.Message;
@@ -36,6 +29,12 @@ import javax.mail.Multipart;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.util.SharedByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;

--- a/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/SmtpSimpleSecureEmailSendTest.java
+++ b/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/SmtpSimpleSecureEmailSendTest.java
@@ -16,17 +16,16 @@
  * under the License.
  */
 
-package org.ballerinalang.stdlib.email.testutils.mockServerUtils;
+package org.ballerinalang.stdlib.email.testutils;
 
 import com.icegreen.greenmail.util.DummySSLSocketFactory;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
 
-import java.io.IOException;
-import java.security.Security;
-
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
+import java.io.IOException;
+import java.security.Security;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Oct 08 08:23:30 IST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Purpose
JDK 11 migration. Resolves https://github.com/ballerina-platform/module-ballerina-email/issues/23