### PR TITLE
Remove swan-lake from doc URLs and other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Ballerina Email Library
   [![Github issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-standard-library/module/email.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-standard-library/labels/module%2Femail)
   [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-The Email library is one of the standard library modules of the<a target="_blank" href="https://ballerina.io/"> Ballerina</a> language.
+The Email package is one of the standard library packages of the<a target="_blank" href="https://ballerina.io/"> Ballerina</a> language.
 
 It provides implementation for sending emails over SMTP and receiving (with client and listener modes) over POP3 and IMAP4 protocols.
 
-For more information go to [The Email Module](https://ballerina.io/learn/api-docs/ballerina/email/index.html).
+For more information go to [The Email Package](https://ballerina.io/learn/api-docs/ballerina/email/index.html).
 
 For example demonstrations of the usage, go to [Ballerina By Examples](https://ballerina.io/learn/by-example/).
 
@@ -18,7 +18,7 @@ For example demonstrations of the usage, go to [Ballerina By Examples](https://b
 
 Issues and Projects tabs are disabled for this repository as this is part of the Ballerina Standard Library. To report bugs, request new features, start new discussions, view project boards, etc. please visit Ballerina Standard Library [parent repository](https://github.com/ballerina-platform/ballerina-standard-library). 
 
-This repository only contains the source code for the module.
+This repository only contains the source code for the package.
 
 ## Building from the Source
 
@@ -36,7 +36,7 @@ This repository only contains the source code for the module.
 
 Execute the commands below to build from source.
 
-1. To build the library:
+1. To build the package:
 
     ```shell script
         ./gradlew clean build
@@ -48,7 +48,7 @@ Execute the commands below to build from source.
         ./gradlew clean test
     ```
 
-3. To build the module without the tests:
+3. To build the package without the tests:
 
     ```shell script
         ./gradlew clean build -x test

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The Email library is one of the standard library modules of the<a target="_blank
 
 It provides implementation for sending emails over SMTP and receiving (with client and listener modes) over POP3 and IMAP4 protocols.
 
-For more information go to [The Email Module](https://ballerina.io/swan-lake/learn/api-docs/ballerina/email/index.html).
+For more information go to [The Email Module](https://ballerina.io/learn/api-docs/ballerina/email/index.html).
 
-For example demonstrations of the usage, go to [Ballerina By Examples](https://ballerina.io/swan-lake/learn/by-example/).
+For example demonstrations of the usage, go to [Ballerina By Examples](https://ballerina.io/learn/by-example/).
 
 ## Issues and Projects 
 

--- a/email-ballerina/Package.md
+++ b/email-ballerina/Package.md
@@ -175,7 +175,7 @@ service "emailObserver" on emailListener {
 }
 ```
 
-For information on the operations, which you can perform with this package, see the below **Functions**. For examples on the usage of the operation, see the following.
+For information on the operations, which you can perform with this package, see the **Functions**  below. For examples of the usage of the operation, see the following.
   * [Send Emails Example](https://ballerina.io/learn/by-example/send-email.html)
   * [Receive Emails using a client Example](https://ballerina.io/learn/by-example/receive-email-using-client.html)
   * [Receive Emails using a listener Example](https://ballerina.io/learn/by-example/receive-email-using-listener.html)

--- a/email-ballerina/Package.md
+++ b/email-ballerina/Package.md
@@ -1,10 +1,10 @@
-## Module Overview
+## Package Overview
 
-This module contains functions to perform email operations such as sending and reading emails using the SMTP, POP3, and IMAP4 protocols.
+This package contains functions to perform email operations such as sending and reading emails using the SMTP, POP3, and IMAP4 protocols.
 
 ### Client
 
-This module supports the following three client types.
+This package supports the following three client types.
 
 - `email:SmtpClient` - The client, which supports sending an email using the SMTP protocol.
 - `email:PopClient` - The client, which supports receiving an email using the POP3 protocol.
@@ -64,7 +64,7 @@ email:Error? response = smtpClient->sendEmail(
     ["receiver1@email.com", "receiver2@email.com"],
     "Sample Email",
     "author@email.com",
-    "This is a sample email.",
+    body="This is a sample email.",
     cc=["receiver3@email.com", "receiver4@email.com"],
     bcc=["receiver5@email.com"],
     sender="sender@email.com",
@@ -175,4 +175,7 @@ service "emailObserver" on emailListener {
 }
 ```
 
-For information on the operations, which you can perform with this module, see the below **Functions**. For examples on the usage of the operation, see the [Send and Receive Emails Example](https://ballerina.io/learn/by-example/send-and-receive-emails.html).
+For information on the operations, which you can perform with this package, see the below **Functions**. For examples on the usage of the operation, see the following.
+  * [Send Emails Example](https://ballerina.io/learn/by-example/send-email.html)
+  * [Receive Emails using a client Example](https://ballerina.io/learn/by-example/receive-email-using-client.html)
+  * [Receive Emails using a listener Example](https://ballerina.io/learn/by-example/receive-email-using-listener.html)

--- a/email-ballerina/Package.md
+++ b/email-ballerina/Package.md
@@ -175,4 +175,4 @@ service "emailObserver" on emailListener {
 }
 ```
 
-For information on the operations, which you can perform with this module, see the below **Functions**. For examples on the usage of the operation, see the [Send and Receive Emails Example](https://ballerina.io/swan-lake/learn/by-example/send-and-receive-emails.html).
+For information on the operations, which you can perform with this module, see the below **Functions**. For examples on the usage of the operation, see the [Send and Receive Emails Example](https://ballerina.io/learn/by-example/send-and-receive-emails.html).

--- a/email-ballerina/commons.bal
+++ b/email-ballerina/commons.bal
@@ -34,7 +34,7 @@ public type Message record {|
     string|string[] to;
     string subject;
     string 'from;
-    string body;
+    string body; // TODO think about making optional
     string htmlBody?;
     string|string[] cc?;
     string|string[] bcc?;
@@ -42,7 +42,8 @@ public type Message record {|
     string contentType?;
     map<string> headers?;
     string sender?;
-    Attachment|(mime:Entity|Attachment)[] attachments?;
+    mime:Entity|Attachment|(mime:Entity|Attachment)[] attachments?;
+    // TODO update like mime:Entity|Attachment|(mime:Entity|Attachment)[]
 |};
 
 # Optional parameters for an Email message.
@@ -63,7 +64,8 @@ public type Options record {|
     string|string[] bcc?;
     string|string[] replyTo?;
     string sender?;
-    Attachment|(mime:Entity|Attachment)[] attachments?;
+    mime:Entity|Attachment|(mime:Entity|Attachment)[] attachments?;
+    // TODO update like mime:Entity|Attachment|(mime:Entity|Attachment)[]
 |};
 
 # Email attachment.
@@ -80,10 +82,12 @@ public type Attachment record {|
 # + certificate - Server certificate
 # + protocol - SSL or TLS protocol
 # + ciphers - Ciper used
+# + verifyHostname - Enable hostname verification
 public type SecureSocket record {|
     Certificate certificate;
     Protocol? protocol = ();
     string[]? ciphers = ();
+    boolean verifyHostname = true;
 |};
 
 # Certificate configuration.

--- a/email-ballerina/commons.bal
+++ b/email-ballerina/commons.bal
@@ -47,7 +47,7 @@ public type Message record {|
 
 # Optional parameters for an Email message.
 #
-# + body - Text typed body of the email message
+# + body - Text-type body of the email message
 # + htmlBody - HTML typed body of the email message
 # + contentType - Content Type of the Body
 # + headers - Header list

--- a/email-ballerina/commons.bal
+++ b/email-ballerina/commons.bal
@@ -34,7 +34,7 @@ public type Message record {|
     string|string[] to;
     string subject;
     string 'from;
-    string body; // TODO think about making optional
+    string body;
     string htmlBody?;
     string|string[] cc?;
     string|string[] bcc?;
@@ -43,7 +43,6 @@ public type Message record {|
     map<string> headers?;
     string sender?;
     mime:Entity|Attachment|(mime:Entity|Attachment)[] attachments?;
-    // TODO update like mime:Entity|Attachment|(mime:Entity|Attachment)[]
 |};
 
 # Optional parameters for an Email message.

--- a/email-ballerina/commons.bal
+++ b/email-ballerina/commons.bal
@@ -34,7 +34,7 @@ public type Message record {|
     string|string[] to;
     string subject;
     string 'from;
-    string body;
+    string body?;
     string htmlBody?;
     string|string[] cc?;
     string|string[] bcc?;
@@ -47,6 +47,7 @@ public type Message record {|
 
 # Optional parameters for an Email message.
 #
+# + body - Text typed body of the email message
 # + htmlBody - HTML typed body of the email message
 # + contentType - Content Type of the Body
 # + headers - Header list
@@ -56,6 +57,7 @@ public type Message record {|
 # + sender - Sender's address
 # + attachments - Email attachements
 public type Options record {|
+    string body?;
     string htmlBody?;
     string contentType?;
     map<string> headers?;

--- a/email-ballerina/commons.bal
+++ b/email-ballerina/commons.bal
@@ -64,7 +64,6 @@ public type Options record {|
     string|string[] replyTo?;
     string sender?;
     mime:Entity|Attachment|(mime:Entity|Attachment)[] attachments?;
-    // TODO update like mime:Entity|Attachment|(mime:Entity|Attachment)[]
 |};
 
 # Email attachment.

--- a/email-ballerina/imap_client_endpoint.bal
+++ b/email-ballerina/imap_client_endpoint.bal
@@ -26,7 +26,7 @@ public client class ImapClient {
     # + password - Password of the IMAP Client
     # + clientConfig - Configurations for the IMAP Client
     # + return - An `email:Error` if failed while creating the client or else `()`
-    public isolated function init(@untainted string host, @untainted string username, @untainted string password,
+    public isolated function init(string host, string username, string password,
             ImapConfig clientConfig = {}) returns Error? {
         return initImapClientEndpoint(self, host, username, password, clientConfig);
     }
@@ -60,11 +60,11 @@ isolated function imapRead(ImapClient clientEndpoint, string folder) returns Mes
 #
 # + port - Port number of the IMAP server
 # + security - Type of security channel
-# + properties - IMAP properties to override the existing configuration
 # + secureSocket - Secure socket configuration
 public type ImapConfig record {|
     int port = 993;
-    Security? security = ();
-    map<string>? properties = ();
-    SecureSocket? secureSocket = ();
+    Security security = SSL;
+    //map<string>? properties = ();
+    SecureSocket secureSocket?;
+    //SecureSocket? secureSocket = ();
 |};

--- a/email-ballerina/imap_client_endpoint.bal
+++ b/email-ballerina/imap_client_endpoint.bal
@@ -64,7 +64,5 @@ isolated function imapRead(ImapClient clientEndpoint, string folder) returns Mes
 public type ImapConfig record {|
     int port = 993;
     Security security = SSL;
-    //map<string>? properties = ();
     SecureSocket secureSocket?;
-    //SecureSocket? secureSocket = ();
 |};

--- a/email-ballerina/imap_listener_endpoint.bal
+++ b/email-ballerina/imap_listener_endpoint.bal
@@ -32,8 +32,6 @@ public class ImapListener {
         ImapConfig imapConfig = {
              port: listenerConfig.port,
              security: listenerConfig.security
-             //properties: listenerConfig.properties,
-             //secureSocket: listenerConfig.secureSocket
         };
         SecureSocket? secureSocketParam = listenerConfig?.secureSocket;
         if (!(secureSocketParam is ())) {
@@ -174,8 +172,6 @@ public type ImapListenerConfig record {|
     int pollingIntervalInMillis = 60000;
     int port = 993;
     Security security = SSL;
-    //map<string>? properties = ();
     string? cronExpression = ();
     SecureSocket secureSocket?;
-    //SecureSocket? secureSocket = ();
 |};

--- a/email-ballerina/imap_listener_endpoint.bal
+++ b/email-ballerina/imap_listener_endpoint.bal
@@ -31,10 +31,14 @@ public class ImapListener {
         self.config = listenerConfig;
         ImapConfig imapConfig = {
              port: listenerConfig.port,
-             security: listenerConfig.security,
-             properties: listenerConfig.properties,
-             secureSocket: listenerConfig.secureSocket
+             security: listenerConfig.security
+             //properties: listenerConfig.properties,
+             //secureSocket: listenerConfig.secureSocket
         };
+        SecureSocket? secureSocketParam = listenerConfig?.secureSocket;
+        if (!(secureSocketParam is ())) {
+            imapConfig.secureSocket = secureSocketParam;
+        }
         return externalInit(self, self.config, imapConfig, "IMAP");
     }
 
@@ -161,7 +165,6 @@ final service isolated object{} imapAppointmentService = service object {
 # + pollingIntervalInMillis - Periodic time interval to check new update
 # + port - Port number of the IMAP server
 # + security - Type of security channel
-# + properties - IMAP4 properties to override the existing configuration
 # + cronExpression - Cron expression to check new update
 # + secureSocket - Secure socket configuration
 public type ImapListenerConfig record {|
@@ -170,8 +173,9 @@ public type ImapListenerConfig record {|
     string password;
     int pollingIntervalInMillis = 60000;
     int port = 993;
-    Security? security = ();
-    map<string>? properties = ();
+    Security security = SSL;
+    //map<string>? properties = ();
     string? cronExpression = ();
-    SecureSocket? secureSocket = ();
+    SecureSocket secureSocket?;
+    //SecureSocket? secureSocket = ();
 |};

--- a/email-ballerina/pop_client_endpoint.bal
+++ b/email-ballerina/pop_client_endpoint.bal
@@ -64,7 +64,5 @@ isolated function popRead(PopClient clientEndpoint, string folder) returns Messa
 public type PopConfig record {|
     int port = 995;
     Security security = SSL;
-    //map<string>? properties = ();
     SecureSocket secureSocket?;
-    //SecureSocket? secureSocket = ();
 |};

--- a/email-ballerina/pop_client_endpoint.bal
+++ b/email-ballerina/pop_client_endpoint.bal
@@ -26,7 +26,7 @@ public client class PopClient {
     # + password - Password of the POP Client
     # + clientConfig - Configurations for the POP Client
     # + return - An `email:Error` if creating the client failed or else `()`
-    public isolated function init(@untainted string host, @untainted string username, @untainted string password,
+    public isolated function init(string host, string username, string password,
             PopConfig clientConfig = {}) returns Error? {
         return initPopClientEndpoint(self, host, username, password, clientConfig);
     }
@@ -60,11 +60,11 @@ isolated function popRead(PopClient clientEndpoint, string folder) returns Messa
 #
 # + port - Port number of the POP server
 # + security - Type of security channel
-# + properties - POP3 properties to override the existing configuration
 # + secureSocket - Secure socket configuration
 public type PopConfig record {|
     int port = 995;
-    Security? security = ();
-    map<string>? properties = ();
-    SecureSocket? secureSocket = ();
+    Security security = SSL;
+    //map<string>? properties = ();
+    SecureSocket secureSocket?;
+    //SecureSocket? secureSocket = ();
 |};

--- a/email-ballerina/pop_listener_endpoint.bal
+++ b/email-ballerina/pop_listener_endpoint.bal
@@ -32,10 +32,14 @@ public class PopListener {
         self.config = listenerConfig;
         PopConfig popConfig = {
              port: listenerConfig.port,
-             security: listenerConfig.security,
-             properties: listenerConfig.properties,
-             secureSocket: listenerConfig.secureSocket
+             security: listenerConfig.security
+             //properties: listenerConfig.properties,
+             //secureSocket: listenerConfig.secureSocket
         };
+        SecureSocket? secureSocketParam = listenerConfig?.secureSocket;
+        if (!(secureSocketParam is ())) {
+            popConfig.secureSocket = secureSocketParam;
+        }
         return externalInit(self, self.config, popConfig, "POP");
     }
 
@@ -162,7 +166,6 @@ final service isolated object{} popAppointmentService = service object {
 # + pollingIntervalInMillis - Periodic time interval to check new update
 # + port - Port number of the POP server
 # + security - Type of security channel
-# + properties - POP3 properties to override the existing configuration
 # + cronExpression - Cron expression to check new update
 # + secureSocket - Secure socket configuration
 public type PopListenerConfig record {|
@@ -171,10 +174,11 @@ public type PopListenerConfig record {|
     string password;
     int pollingIntervalInMillis = 60000;
     int port = 995;
-    Security? security = ();
-    map<string>? properties = ();
+    Security security = SSL;
+    //map<string>? properties = ();
     string? cronExpression = ();
-    SecureSocket? secureSocket = ();
+    SecureSocket secureSocket?;
+    //SecureSocket? secureSocket = ();
 |};
 
 isolated function poll(PopListener|ImapListener listenerEndpoint) returns error? = @java:Method{

--- a/email-ballerina/pop_listener_endpoint.bal
+++ b/email-ballerina/pop_listener_endpoint.bal
@@ -33,8 +33,6 @@ public class PopListener {
         PopConfig popConfig = {
              port: listenerConfig.port,
              security: listenerConfig.security
-             //properties: listenerConfig.properties,
-             //secureSocket: listenerConfig.secureSocket
         };
         SecureSocket? secureSocketParam = listenerConfig?.secureSocket;
         if (!(secureSocketParam is ())) {
@@ -175,10 +173,8 @@ public type PopListenerConfig record {|
     int pollingIntervalInMillis = 60000;
     int port = 995;
     Security security = SSL;
-    //map<string>? properties = ();
     string? cronExpression = ();
     SecureSocket secureSocket?;
-    //SecureSocket? secureSocket = ();
 |};
 
 isolated function poll(PopListener|ImapListener listenerEndpoint) returns error? = @java:Method{

--- a/email-ballerina/smtp_client_endpoint.bal
+++ b/email-ballerina/smtp_client_endpoint.bal
@@ -41,7 +41,6 @@ public client class SmtpClient {
     # + email - An `email:Message` message, which needs to be sent to the recipient
     # + return - An `email:Error` if failed to send the message to the recipient or else `()`
     remote isolated function sendEmailMessage(Message email) returns Error? {
-        var body = email.body;
         if (email?.contentType == ()) {
             email.contentType = "text/plain";
         } else if (!self.containsType(email?.contentType, "text")) {
@@ -60,17 +59,19 @@ public client class SmtpClient {
     # + to - TO address list
     # + subject - Subject of email
     # + from - From address
-    # + body - Text typed body of the email message
     # + options - Optional parameters of the email
     # + return - An `email:Error` if failed to send the message to the recipient or else `()`
-    remote isolated function sendEmail(string|string[] to, string subject, string 'from, string body, *Options options)
+    remote isolated function sendEmail(string|string[] to, string subject, string 'from, *Options options)
             returns Error? {
         Message email = {
             to: to,
             subject: subject,
-            body: body,
             'from: 'from
         };
+        string? body = options?.body;
+        if (!(body is ())) {
+            email.body = <string>body;
+        }
         string? htmlBody = options?.htmlBody;
         if (!(htmlBody is ())) {
             email.htmlBody = <string>htmlBody;

--- a/email-ballerina/smtp_client_endpoint.bal
+++ b/email-ballerina/smtp_client_endpoint.bal
@@ -27,8 +27,8 @@ public client class SmtpClient {
     # + password - Password of the SMTP Client
     # + clientConfig - Configurations for SMTP Client
     # + return - An `email:Error` if failed to initialize or else `()`
-    public isolated function init(@untainted string host, @untainted string username, @untainted string password,
-            SmtpConfig clientConfig = {}) returns Error? {
+    public isolated function init(string host, string username, string password, SmtpConfig clientConfig = {})
+            returns Error? {
         return initSmtpClientEndpoint(self, host, username, password, clientConfig);
     }
 
@@ -99,9 +99,9 @@ public client class SmtpClient {
         if (!(sender is ())) {
             email.sender = <string>sender;
         }
-        Attachment|(mime:Entity|Attachment)[]? attachments = options?.attachments;
+        mime:Entity|Attachment|(mime:Entity|Attachment)[]? attachments = options?.attachments;
         if (!(attachments is ())) {
-            email.attachments = <Attachment|(mime:Entity|Attachment)[]>attachments;
+            email.attachments = <mime:Entity|Attachment|(mime:Entity|Attachment)[]>attachments;
         }
         return send(self, email);
     }
@@ -116,8 +116,8 @@ public client class SmtpClient {
     }
 
     private isolated function putAttachmentToArray(Message email) {
-        Attachment|(mime:Entity|Attachment)[]|() attachments = email?.attachments;
-        if (attachments is Attachment) {
+        mime:Entity|Attachment|(mime:Entity|Attachment)[]|() attachments = email?.attachments;
+        if (attachments is Attachment || attachments is mime:Entity) {
             email.attachments = [attachments];
         }
     }
@@ -139,11 +139,12 @@ isolated function send(SmtpClient clientEndpoint, Message email) returns Error? 
 #
 # + port - Port number of the SMTP server
 # + security - Type of security channel
-# + properties - SMTP properties to override the existing configuration
 # + secureSocket - Secure socket configuration
 public type SmtpConfig record {|
     int port = 465;
-    Security? security = ();
-    map<string>? properties = ();
-    SecureSocket? secureSocket = ();
+    Security security = SSL;
+    //Security? security = (); // TODO have to remove null check like `Security security = Security.SSL;`
+    //map<string>? properties = (); // TODO remove properties
+    SecureSocket secureSocket?;
+    //SecureSocket? secureSocket = (); // TODO check the change like `SecureSocket secureSocket?;`
 |};

--- a/email-ballerina/smtp_client_endpoint.bal
+++ b/email-ballerina/smtp_client_endpoint.bal
@@ -143,8 +143,5 @@ isolated function send(SmtpClient clientEndpoint, Message email) returns Error? 
 public type SmtpConfig record {|
     int port = 465;
     Security security = SSL;
-    //Security? security = (); // TODO have to remove null check like `Security security = Security.SSL;`
-    //map<string>? properties = (); // TODO remove properties
     SecureSocket secureSocket?;
-    //SecureSocket? secureSocket = (); // TODO check the change like `SecureSocket secureSocket?;`
 |};

--- a/email-ballerina/tests/ImapComplexEmailReceive.bal
+++ b/email-ballerina/tests/ImapComplexEmailReceive.bal
@@ -49,7 +49,10 @@ function testReceiveComplexEmailImap() returns @tainted error? {
     Message|Error? emailResponse = imapClient->receiveEmailMessage();
     if (emailResponse is Message) {
         returnArray[0] = emailResponse.subject;
-        returnArray[1] = <string>emailResponse.body;
+        string? emailBody = <string>emailResponse?.body;
+        if (emailBody is string) {
+            returnArray[1] = emailBody;
+        }
         returnArray[2] = emailResponse.'from;
         returnArray[3] = getNonNilString(emailResponse?.sender);
         returnArray[4] = concatStrings(emailResponse.to);

--- a/email-ballerina/tests/ImapComplexEmailReceive.bal
+++ b/email-ballerina/tests/ImapComplexEmailReceive.bal
@@ -37,9 +37,8 @@ function testReceiveComplexEmailImap() returns @tainted error? {
     }
 
     ImapConfig imapConfig = {
-         port: 31430, // This is an incorrect value. Later the correct value, 3143 will be set via a property.
-         security: START_TLS_AUTO,
-         properties: {"mail.imap.port":"3143"}
+         port: 3143,
+         security: START_TLS_AUTO
     };
     string[] returnArray = [];
     ImapClient|Error imapClientOrError = new (host, username, password, imapConfig);
@@ -56,7 +55,7 @@ function testReceiveComplexEmailImap() returns @tainted error? {
         returnArray[4] = concatStrings(emailResponse.to);
         returnArray[5] = concatStrings(emailResponse?.cc);
         returnArray[6] = concatStrings(emailResponse?.replyTo);
-        Attachment|(mime:Entity|Attachment)[]? attachments = emailResponse?.attachments;
+        mime:Entity|Attachment|(mime:Entity|Attachment)[]? attachments = emailResponse?.attachments;
         if (attachments is (mime:Entity|Attachment)[]) {
             var att0 = attachments[0];
             if (att0 is mime:Entity) {

--- a/email-ballerina/tests/ImapSimpleSecureEmailReceive.bal
+++ b/email-ballerina/tests/ImapSimpleSecureEmailReceive.bal
@@ -30,7 +30,6 @@ function testReceiveSimpleEmailImap() returns @tainted error? {
 
     ImapConfig imapConfig = {
          port: 3993,
-         properties: {"mail.imap.ssl.checkserveridentity":"false"},
          secureSocket: {
              certificate: {
                  path: "tests/resources/certsandkeys/greenmail.crt"
@@ -39,7 +38,8 @@ function testReceiveSimpleEmailImap() returns @tainted error? {
                  name: "TLS",
                  versions: ["TLSv1.2", "TLSv1.1"]
              },
-             ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]
+             ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"],
+             verifyHostname: false
          }
     };
     ImapClient|Error imapClientOrError = new (host, username, password, imapConfig);

--- a/email-ballerina/tests/ListenerImapReceive.bal
+++ b/email-ballerina/tests/ListenerImapReceive.bal
@@ -48,7 +48,7 @@ function getreceivedMessageImap() returns string {
          runtime:sleep(1);
          i += 1;
     }
-    return <@untainted>receivedMessageImap;
+    return receivedMessageImap;
 }
 
 function getreceivedErrorImap() returns string {
@@ -57,7 +57,7 @@ function getreceivedErrorImap() returns string {
          runtime:sleep(1);
          i += 1;
     }
-    return <@untainted>receivedErrorImap;
+    return receivedErrorImap;
 }
 
 @test:Config {
@@ -76,7 +76,6 @@ function testListenEmailImap() returns @tainted error? {
                                password: "abcdef123",
                                pollingIntervalInMillis: 2000,
                                port: 3993,
-                               properties: {"mail.imap.ssl.checkserveridentity":"false"},
                                secureSocket: {
                                     certificate: {
                                         path: "tests/resources/certsandkeys/greenmail.crt"
@@ -85,7 +84,8 @@ function testListenEmailImap() returns @tainted error? {
                                         name: "TLS",
                                         versions: ["TLSv1.2", "TLSv1.1"]
                                     },
-                                    ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]
+                                    ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"],
+                                    verifyHostname: false
                                }
                            });
     if (emailServerOrError is Error) {
@@ -95,12 +95,12 @@ function testListenEmailImap() returns @tainted error? {
 
     service object {} emailObserver = service object {
         remote function onEmailMessage(Message emailMessage) {
-            receivedMessageImap = <@untainted>emailMessage.subject;
+            receivedMessageImap = emailMessage.subject;
             onEmailMessageInvokedImap = true;
         }
 
         remote function onError(Error emailError) {
-            receivedErrorImap = <@untainted>emailError.message();
+            receivedErrorImap = emailError.message();
             onErrorInvokedImap = true;
         }
     };

--- a/email-ballerina/tests/ListenerPopReceive.bal
+++ b/email-ballerina/tests/ListenerPopReceive.bal
@@ -48,7 +48,7 @@ function getreceivedMessagePop() returns string {
          runtime:sleep(1);
          i += 1;
     }
-    return <@untainted>receivedMessagePop;
+    return receivedMessagePop;
 }
 
 function getreceivedErrorPop() returns string {
@@ -57,7 +57,7 @@ function getreceivedErrorPop() returns string {
          runtime:sleep(1);
          i += 1;
     }
-    return <@untainted>receivedErrorPop;
+    return receivedErrorPop;
 }
 
 @test:Config {
@@ -76,7 +76,6 @@ function testListenEmailPop() returns @tainted error? {
                                password: "abcdef123",
                                pollingIntervalInMillis: 2000,
                                port: 3995,
-                               properties: {"mail.pop3.ssl.checkserveridentity":"false"},
                                secureSocket: {
                                     certificate: {
                                         path: "tests/resources/certsandkeys/greenmail.crt"
@@ -85,7 +84,8 @@ function testListenEmailPop() returns @tainted error? {
                                         name: "TLS",
                                         versions: ["TLSv1.2", "TLSv1.1"]
                                     },
-                                    ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]
+                                    ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"],
+                                    verifyHostname: false
                                }
                            });
     if (emailServerOrError is Error) {
@@ -95,12 +95,12 @@ function testListenEmailPop() returns @tainted error? {
 
     service object {} emailObserver = service object {
         remote function onEmailMessage(Message emailMessage) {
-            receivedMessagePop = <@untainted>emailMessage.subject;
+            receivedMessagePop = emailMessage.subject;
             onEmailMessageInvokedPop = true;
         }
 
         remote function onError(Error emailError) {
-            receivedErrorPop = <@untainted>emailError.message();
+            receivedErrorPop = emailError.message();
             onErrorInvokedPop = true;
         }
     };

--- a/email-ballerina/tests/PopComplexEmailReceive.bal
+++ b/email-ballerina/tests/PopComplexEmailReceive.bal
@@ -50,7 +50,10 @@ function testReceiveComplexEmailPop() returns @tainted error? {
     Message|Error? emailResponse = popClient->receiveEmailMessage();
     if (emailResponse is Message) {
         returnArray[0] = emailResponse.subject;
-        returnArray[1] = <string>emailResponse.body;
+        string? emailBody = <string>emailResponse?.body;
+        if (emailBody is string) {
+            returnArray[1] = emailBody;
+        }
         returnArray[2] = emailResponse.'from;
         returnArray[3] = getNonNilString(emailResponse?.sender);
         returnArray[4] = concatStrings(emailResponse.to);

--- a/email-ballerina/tests/PopComplexEmailReceive.bal
+++ b/email-ballerina/tests/PopComplexEmailReceive.bal
@@ -38,9 +38,8 @@ function testReceiveComplexEmailPop() returns @tainted error? {
     }
 
     PopConfig popConfig = {
-         port: 31100, // This is an incorrect value. Later the correct value, 3110 will be set via a property.
-         security: START_TLS_AUTO,
-         properties: {"mail.pop3.port":"3110"}
+         port: 3110,
+         security: START_TLS_AUTO
     };
     string[] returnArray = [];
     PopClient|Error popClientOrError = new (host, username, password, popConfig);
@@ -57,7 +56,7 @@ function testReceiveComplexEmailPop() returns @tainted error? {
         returnArray[4] = concatStrings(emailResponse.to);
         returnArray[5] = concatStrings(emailResponse?.cc);
         returnArray[6] = concatStrings(emailResponse?.replyTo);
-        Attachment|(mime:Entity|Attachment)[]? attachments = emailResponse?.attachments;
+        mime:Entity|Attachment|(mime:Entity|Attachment)[]? attachments = emailResponse?.attachments;
         if (attachments is (mime:Entity|Attachment)[]) {
             var att0 = attachments[0];
             if (att0 is mime:Entity) {

--- a/email-ballerina/tests/PopSimpleSecureEmailReceive.bal
+++ b/email-ballerina/tests/PopSimpleSecureEmailReceive.bal
@@ -31,7 +31,6 @@ function testReceiveSimpleEmailPop() returns @tainted error? {
 
     PopConfig popConfig = {
          port: 3995,
-         properties: {"mail.pop3.ssl.checkserveridentity":"false"},
          secureSocket: {
              certificate: {
                  path: "tests/resources/certsandkeys/greenmail.crt"
@@ -40,7 +39,8 @@ function testReceiveSimpleEmailPop() returns @tainted error? {
                  name: "TLS",
                  versions: ["TLSv1.2", "TLSv1.1"]
              },
-             ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]
+             ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"],
+             verifyHostname: false
          }
     };
     PopClient|Error popClientOrError = new (host, username, password, popConfig);

--- a/email-ballerina/tests/SmtpComplexEmailSend.bal
+++ b/email-ballerina/tests/SmtpComplexEmailSend.bal
@@ -38,9 +38,8 @@ function testSendComplexEmail() returns @tainted error? {
     error? serverStatus = startComplexSmtpServer();
 
     SmtpConfig smtpConfig = {
-        port: 30250, // This is an incorrect value. Later the correct value, 3025 will be set via a property.
-        security: START_TLS_AUTO,
-        properties: {"mail.smtp.port":"3025"}
+        port: 3025,
+        security: START_TLS_AUTO
     };
 
     SmtpClient|Error smtpClientOrError = new (host, username,  password, smtpConfig);

--- a/email-ballerina/tests/SmtpComplexEmailSend.bal
+++ b/email-ballerina/tests/SmtpComplexEmailSend.bal
@@ -18,7 +18,7 @@ import ballerina/jballerina.java;
 import ballerina/mime;
 import ballerina/test;
 
-@test:Config {dependsOn: [testSendEmailWithOptions], enable: false}
+@test:Config {dependsOn: [testSendEmailWithOptions]}
 function testSendComplexEmail() returns @tainted error? {
 
     string host = "127.0.0.1";

--- a/email-ballerina/tests/SmtpEmailSendWithOptions.bal
+++ b/email-ballerina/tests/SmtpEmailSendWithOptions.bal
@@ -18,7 +18,7 @@ import ballerina/jballerina.java;
 import ballerina/mime;
 import ballerina/test;
 
-@test:Config {dependsOn: [testSendSimpleEmail], enable: false}
+@test:Config {dependsOn: [testSendSimpleEmail]}
 function testSendEmailWithOptions() returns @tainted error? {
 
     string host = "127.0.0.1";

--- a/email-ballerina/tests/SmtpEmailSendWithOptions.bal
+++ b/email-ballerina/tests/SmtpEmailSendWithOptions.bal
@@ -38,9 +38,8 @@ function testSendEmailWithOptions() returns @tainted error? {
     error? serverStatus = startSendWithOptionsSmtpServer();
 
     SmtpConfig smtpConfig = {
-        port: 30250, // This is an incorrect value. Later the correct value, 3025 will be set via a property.
-        security: START_TLS_AUTO,
-        properties: {"mail.smtp.port":"3025"}
+        port: 3025,
+        security: START_TLS_AUTO
     };
 
     SmtpClient|Error smtpClientOrError = new (host, username,  password, smtpConfig);

--- a/email-ballerina/tests/SmtpEmailSendWithOptions.bal
+++ b/email-ballerina/tests/SmtpEmailSendWithOptions.bal
@@ -91,7 +91,7 @@ function testSendEmailWithOptions() returns @tainted error? {
     //Create an array to hold all the body parts.
     (mime:Entity|Attachment)[] bodyParts = [bodyPart1, bodyPart2, bodyPart3, bodyPart4, bodyPart5, bodyPart6, att7];
 
-    Error? response = smtpClient->sendEmail(toAddresses, subject, fromAddress, body, cc=ccAddresses, bcc=bccAddresses,
+    Error? response = smtpClient->sendEmail(toAddresses, subject, fromAddress, body=body, cc=ccAddresses, bcc=bccAddresses,
         htmlBody=htmlBody, contentType=contentType, headers={header1_name: "header1_value"}, sender=sender,
         replyTo=replyToAddresses, attachments=bodyParts);
     if (response is Error) {

--- a/email-ballerina/tests/SmtpSimpleSecureEmailSend.bal
+++ b/email-ballerina/tests/SmtpSimpleSecureEmailSend.bal
@@ -32,7 +32,6 @@ function testSendSimpleEmail() returns @tainted error? {
     error? serverStatus = startSimpleSecureSmtpServer();
     SmtpConfig smtpConfig = {
         port: 3465,
-        properties: {"mail.smtp.ssl.checkserveridentity":"false"},
         secureSocket: {
             certificate: {
                 path: "tests/resources/certsandkeys/greenmail.crt"
@@ -41,7 +40,8 @@ function testSendSimpleEmail() returns @tainted error? {
                 name: "TLS",
                 versions: ["TLSv1.2", "TLSv1.1"]
             },
-            ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]
+            ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"],
+            verifyHostname: false
         }
     };
 

--- a/email-native/src/main/java/org/ballerinalang/stdlib/email/client/SmtpClient.java
+++ b/email-native/src/main/java/org/ballerinalang/stdlib/email/client/SmtpClient.java
@@ -96,7 +96,6 @@ public class SmtpClient {
         } catch (MessagingException | IOException e) {
             log.error("Failed to send message to SMTP server : ", e);
             return CommonUtil.getBallerinaError(EmailConstants.SEND_ERROR, e.getMessage());
-            // TODO verify if we want to close
         }
     }
 

--- a/email-native/src/main/java/org/ballerinalang/stdlib/email/client/SmtpClient.java
+++ b/email-native/src/main/java/org/ballerinalang/stdlib/email/client/SmtpClient.java
@@ -96,6 +96,7 @@ public class SmtpClient {
         } catch (MessagingException | IOException e) {
             log.error("Failed to send message to SMTP server : ", e);
             return CommonUtil.getBallerinaError(EmailConstants.SEND_ERROR, e.getMessage());
+            // TODO verify if we want to close
         }
     }
 

--- a/email-native/src/main/java/org/ballerinalang/stdlib/email/util/CommonUtil.java
+++ b/email-native/src/main/java/org/ballerinalang/stdlib/email/util/CommonUtil.java
@@ -103,23 +103,6 @@ public class CommonUtil {
         return buffer.toByteArray();
     }
 
-//    /**
-//     * Add custom properties from the Ballerina configuration.
-//     *
-//     * @param customProperties Custom properties from Ballerina
-//     * @param properties Properties to be used to create the session
-//     */
-//    public static void addCustomProperties(BMap<BString, Object> customProperties, Properties properties) {
-//        if (customProperties != null) {
-//            for (BString propertyName : customProperties.getKeys()) {
-//                properties.put(propertyName.getValue(),
-//                               customProperties.getStringValue(propertyName).getValue());
-//                log.debug("Added custom protocol property with Name: " + propertyName + ", Value: "
-//                                  + customProperties.getStringValue(propertyName).getValue());
-//            }
-//        }
-//    }
-
     protected static SSLSocketFactory createSSLSocketFactory(File crtFile, String protocol)
             throws GeneralSecurityException, IOException {
         SSLContext sslContext = SSLContext.getInstance(protocol);

--- a/email-native/src/main/java/org/ballerinalang/stdlib/email/util/CommonUtil.java
+++ b/email-native/src/main/java/org/ballerinalang/stdlib/email/util/CommonUtil.java
@@ -22,8 +22,6 @@ import com.sun.mail.util.MailSSLSocketFactory;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
-import io.ballerina.runtime.api.values.BMap;
-import io.ballerina.runtime.api.values.BString;
 import org.ballerinalang.mime.util.MimeConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +36,6 @@ import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.Properties;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -106,22 +103,22 @@ public class CommonUtil {
         return buffer.toByteArray();
     }
 
-    /**
-     * Add custom properties from the Ballerina configuration.
-     *
-     * @param customProperties Custom properties from Ballerina
-     * @param properties Properties to be used to create the session
-     */
-    public static void addCustomProperties(BMap<BString, Object> customProperties, Properties properties) {
-        if (customProperties != null) {
-            for (BString propertyName : customProperties.getKeys()) {
-                properties.put(propertyName.getValue(),
-                               customProperties.getStringValue(propertyName).getValue());
-                log.debug("Added custom protocol property with Name: " + propertyName + ", Value: "
-                                  + customProperties.getStringValue(propertyName).getValue());
-            }
-        }
-    }
+//    /**
+//     * Add custom properties from the Ballerina configuration.
+//     *
+//     * @param customProperties Custom properties from Ballerina
+//     * @param properties Properties to be used to create the session
+//     */
+//    public static void addCustomProperties(BMap<BString, Object> customProperties, Properties properties) {
+//        if (customProperties != null) {
+//            for (BString propertyName : customProperties.getKeys()) {
+//                properties.put(propertyName.getValue(),
+//                               customProperties.getStringValue(propertyName).getValue());
+//                log.debug("Added custom protocol property with Name: " + propertyName + ", Value: "
+//                                  + customProperties.getStringValue(propertyName).getValue());
+//            }
+//        }
+//    }
 
     protected static SSLSocketFactory createSSLSocketFactory(File crtFile, String protocol)
             throws GeneralSecurityException, IOException {

--- a/email-native/src/main/java/org/ballerinalang/stdlib/email/util/EmailAccessUtil.java
+++ b/email-native/src/main/java/org/ballerinalang/stdlib/email/util/EmailAccessUtil.java
@@ -79,9 +79,6 @@ import static org.ballerinalang.stdlib.email.util.EmailConstants.PROPS_START_TLS
 import static org.ballerinalang.stdlib.email.util.EmailConstants.PROPS_START_TLS_NEVER;
 import static org.ballerinalang.stdlib.email.util.EmailConstants.PROPS_VERIFY_HOSTNAME;
 
-//import static org.ballerinalang.stdlib.email.util.CommonUtil.createDefaultSSLSocketFactory;
-//import static org.ballerinalang.mime.util.MimeConstants.PROTOCOL_MIME_PKG_ID;
-
 /**
  * Contains utility functions related to the POP and IMAP protocols.
  *
@@ -133,8 +130,6 @@ public class EmailAccessUtil {
                 (EmailConstants.PROPS_SECURE_SOCKET), properties);
         properties.put(EmailConstants.PROPS_POP_AUTH, "true");
         properties.put(EmailConstants.MAIL_STORE_PROTOCOL, EmailConstants.POP_PROTOCOL);
-//        CommonUtil.addCustomProperties(
-//                (BMap<BString, Object>) emailAccessConfig.getMapValue(EmailConstants.PROPS_PROPERTIES), properties);
         if (log.isDebugEnabled()) {
             Set<String> propertySet = properties.stringPropertyNames();
             log.debug("POP3 Properties set are as follows.");
@@ -187,8 +182,6 @@ public class EmailAccessUtil {
         properties.put(EmailConstants.MAIL_STORE_PROTOCOL, EmailConstants.IMAP_PROTOCOL);
         addImapCertificate((BMap<BString, Object>) emailAccessConfig.getMapValue
                 (EmailConstants.PROPS_SECURE_SOCKET), properties);
-//        CommonUtil.addCustomProperties(
-//                (BMap<BString, Object>) emailAccessConfig.getMapValue(EmailConstants.PROPS_PROPERTIES), properties);
         if (log.isDebugEnabled()) {
             Set<String> propertySet = properties.stringPropertyNames();
             log.debug("IMAP4 Properties set are as follows.");

--- a/email-native/src/main/java/org/ballerinalang/stdlib/email/util/EmailConstants.java
+++ b/email-native/src/main/java/org/ballerinalang/stdlib/email/util/EmailConstants.java
@@ -75,6 +75,7 @@ public class EmailConstants {
     public static final BString PROPS_CERT_PROTOCOL_VERSIONS = StringUtils.fromString("versions");
     public static final BString PROPS_CERT_CIPHERS = StringUtils.fromString("ciphers");
     public static final BString PROPS_CERT_PATH = StringUtils.fromString("path");
+    public static final BString PROPS_VERIFY_HOSTNAME = StringUtils.fromString("verifyHostname");
 
     // Common constants to POP and IMAP
     public static final BString PROPS_PROPERTIES = StringUtils.fromString("properties");
@@ -140,7 +141,7 @@ public class EmailConstants {
 
     // SMTP related constants
     public static final String PROPS_SESSION = "session";
-    public static final String PROPS_ENABLE_SSL = "mail.smtp.ssl.enable";
+    public static final String PROPS_SMTP_ENABLE_SSL = "mail.smtp.ssl.enable";
     public static final String PROPS_SMTP_CHECK_SERVER_IDENTITY = "mail.smtp.ssl.checkserveridentity";
     public static final String PROPS_SMTP_SOCKET_FACTORY_FALLBACK = "mail.smtp.socketFactory.fallback";
     public static final String PROPS_SMTP_SOCKET_FACTORY = "mail.smtp.ssl.socketFactory";

--- a/email-native/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
+++ b/email-native/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
@@ -148,7 +148,7 @@ public class SmtpUtil {
         Address[] bccAddressArray = extractAddressLists(message, EmailConstants.MESSAGE_BCC);
         Address[] replyToAddressArray = extractAddressLists(message, EmailConstants.MESSAGE_REPLY_TO);
         String subject = message.getStringValue(EmailConstants.MESSAGE_SUBJECT).getValue();
-        String messageBody = message.getStringValue(EmailConstants.MESSAGE_MESSAGE_BODY).getValue();
+        String messageBody = getNullCheckedString(message.getStringValue(EmailConstants.MESSAGE_MESSAGE_BODY));
         String htmlMessageBody = getNullCheckedString(message.getStringValue(EmailConstants.MESSAGE_HTML_MESSAGE_BODY));
         String bodyContentType = message.getStringValue(EmailConstants.MESSAGE_BODY_CONTENT_TYPE).getValue();
         String fromAddress = message.getStringValue(EmailConstants.MESSAGE_FROM).getValue();
@@ -173,15 +173,19 @@ public class SmtpUtil {
             emailMessage.setSender(new InternetAddress(senderAddress));
         }
         Object attachments = message.get(EmailConstants.MESSAGE_ATTACHMENTS);
-        if (attachments == null) {
-            if (!htmlMessageBody.isEmpty()) {
-                addTextAndHtmlContentToEmail(emailMessage, messageBody, htmlMessageBody);
+
+        if (!messageBody.isEmpty()) {
+            if (attachments == null) {
+                if (!htmlMessageBody.isEmpty()) {
+                    addTextAndHtmlContentToEmail(emailMessage, messageBody, htmlMessageBody);
+                } else {
+                    emailMessage.setContent(messageBody, bodyContentType);
+                }
             } else {
-                emailMessage.setContent(messageBody, bodyContentType);
+                addBodyAndAttachments(emailMessage, messageBody, htmlMessageBody, bodyContentType, attachments);
             }
-        } else {
-            addBodyAndAttachments(emailMessage, messageBody, htmlMessageBody, bodyContentType, attachments);
         }
+
         addMessageHeaders(emailMessage, message);
         return emailMessage;
     }

--- a/email-native/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
+++ b/email-native/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
@@ -120,8 +120,6 @@ public class SmtpUtil {
         }
         addCertificate((BMap<BString, Object>) smtpConfig.getMapValue(EmailConstants.PROPS_SECURE_SOCKET),
                 properties);
-//        CommonUtil.addCustomProperties(
-//                (BMap<BString, Object>) smtpConfig.getMapValue(EmailConstants.PROPS_PROPERTIES), properties);
         if (log.isDebugEnabled()) {
             Set<String> propertySet = properties.stringPropertyNames();
             log.debug("SMTP Properties set are as follows.");

--- a/email-native/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
+++ b/email-native/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
@@ -174,16 +174,16 @@ public class SmtpUtil {
         }
         Object attachments = message.get(EmailConstants.MESSAGE_ATTACHMENTS);
 
-        if (!messageBody.isEmpty()) {
-            if (attachments == null) {
-                if (!htmlMessageBody.isEmpty()) {
-                    addTextAndHtmlContentToEmail(emailMessage, messageBody, htmlMessageBody);
-                } else {
-                    emailMessage.setContent(messageBody, bodyContentType);
-                }
-            } else {
-                addBodyAndAttachments(emailMessage, messageBody, htmlMessageBody, bodyContentType, attachments);
+        if (attachments == null) {
+            boolean hasTextBody = !messageBody.isEmpty();
+            boolean hasHtmlBody = !htmlMessageBody.isEmpty();
+            if (hasTextBody && !hasHtmlBody || !hasTextBody && hasHtmlBody) {
+                emailMessage.setContent(messageBody, bodyContentType);
+            } else if (hasTextBody) { // hasHtmlBody is also implicitly true
+                addTextAndHtmlContentToEmail(emailMessage, messageBody, htmlMessageBody);
             }
+        } else {
+            addBodyAndAttachments(emailMessage, messageBody, htmlMessageBody, bodyContentType, attachments);
         }
 
         addMessageHeaders(emailMessage, message);
@@ -402,8 +402,8 @@ public class SmtpUtil {
 
     private static void addTextAndHtmlContentToEmail(Part emailPart, String textContent, String htmlContent)
             throws MessagingException {
-        Multipart multipart = new MimeMultipart();
-        BodyPart messageBodyPart = new MimeBodyPart();
+        MimeMultipart multipart = new MimeMultipart("alternative");
+        MimeBodyPart messageBodyPart = new MimeBodyPart();
         messageBodyPart.setText(textContent);
         multipart.addBodyPart(messageBodyPart);
         messageBodyPart = new MimeBodyPart();

--- a/email-native/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
+++ b/email-native/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
@@ -69,6 +69,7 @@ import static org.ballerinalang.stdlib.email.util.EmailConstants.PROPS_CERT_PROT
 import static org.ballerinalang.stdlib.email.util.EmailConstants.PROPS_START_TLS_ALWAYS;
 import static org.ballerinalang.stdlib.email.util.EmailConstants.PROPS_START_TLS_AUTO;
 import static org.ballerinalang.stdlib.email.util.EmailConstants.PROPS_START_TLS_NEVER;
+import static org.ballerinalang.stdlib.email.util.EmailConstants.PROPS_VERIFY_HOSTNAME;
 
 /**
  * Contains the utility functions related to the SMTP protocol.
@@ -99,16 +100,17 @@ public class SmtpUtil {
             switch (securityType) {
                 case PROPS_START_TLS_AUTO:
                     properties.put(EmailConstants.PROPS_SMTP_STARTTLS, "true");
-                    properties.put(EmailConstants.PROPS_ENABLE_SSL, "false");
+                    properties.put(EmailConstants.PROPS_SMTP_ENABLE_SSL, "false");
                     break;
                 case PROPS_START_TLS_ALWAYS:
                     properties.put(EmailConstants.PROPS_SMTP_STARTTLS, "true");
                     properties.put(EmailConstants.PROPS_SMTP_STARTTLS_REQUIRED, "true");
-                    properties.put(EmailConstants.PROPS_ENABLE_SSL, "false");
+                    properties.put(EmailConstants.PROPS_SMTP_ENABLE_SSL, "false");
+                    addBasicTransportSecurityProperties(CommonUtil.createDefaultSSLSocketFactory(), properties);
                     break;
                 case PROPS_START_TLS_NEVER:
                     properties.put(EmailConstants.PROPS_SMTP_STARTTLS, "false");
-                    properties.put(EmailConstants.PROPS_ENABLE_SSL, "false");
+                    properties.put(EmailConstants.PROPS_SMTP_ENABLE_SSL, "false");
                     break;
                 default:
                     addBasicTransportSecurityProperties(CommonUtil.createDefaultSSLSocketFactory(), properties);
@@ -118,8 +120,8 @@ public class SmtpUtil {
         }
         addCertificate((BMap<BString, Object>) smtpConfig.getMapValue(EmailConstants.PROPS_SECURE_SOCKET),
                 properties);
-        CommonUtil.addCustomProperties(
-                (BMap<BString, Object>) smtpConfig.getMapValue(EmailConstants.PROPS_PROPERTIES), properties);
+//        CommonUtil.addCustomProperties(
+//                (BMap<BString, Object>) smtpConfig.getMapValue(EmailConstants.PROPS_PROPERTIES), properties);
         if (log.isDebugEnabled()) {
             Set<String> propertySet = properties.stringPropertyNames();
             log.debug("SMTP Properties set are as follows.");
@@ -218,6 +220,14 @@ public class SmtpUtil {
                     properties.put(EmailConstants.PROPS_SMTP_CIPHERSUITES, String.join(" ", supportedCiphers));
                 }
             }
+            if (secureSocket.containsKey(PROPS_VERIFY_HOSTNAME)) {
+                Boolean verifyHostname = secureSocket.getBooleanValue(PROPS_VERIFY_HOSTNAME);
+                if (verifyHostname) {
+                    properties.put(EmailConstants.PROPS_SMTP_CHECK_SERVER_IDENTITY, "true");
+                } else {
+                    properties.put(EmailConstants.PROPS_SMTP_CHECK_SERVER_IDENTITY, "false");
+                }
+            }
         }
     }
 
@@ -226,7 +236,7 @@ public class SmtpUtil {
         properties.put(EmailConstants.PROPS_SMTP_SOCKET_FACTORY_CLASS, EmailConstants.SSL_SOCKET_FACTORY_CLASS);
         properties.put(EmailConstants.PROPS_SMTP_SOCKET_FACTORY_FALLBACK, "false");
         properties.put(EmailConstants.PROPS_SMTP_CHECK_SERVER_IDENTITY, "true");
-        properties.put(EmailConstants.PROPS_ENABLE_SSL, "true");
+        properties.put(EmailConstants.PROPS_SMTP_ENABLE_SSL, "true");
         properties.put(EmailConstants.PROPS_SMTP_STARTTLS, "true");
     }
 

--- a/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/SmtpComplexEmailSendTest.java
+++ b/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/SmtpComplexEmailSendTest.java
@@ -35,6 +35,7 @@ import javax.mail.MessagingException;
 import javax.mail.Multipart;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
 import javax.mail.util.SharedByteArrayInputStream;
 
 import static org.testng.AssertJUnit.assertEquals;
@@ -101,17 +102,19 @@ public class SmtpComplexEmailSendTest {
             assertTrue(message.isMimeType("multipart/*"));
             Multipart multiPart = (Multipart) message.getContent();
             int multiPartCount = multiPart.getCount();
-            assertEquals(9, multiPartCount);
+            assertEquals(8, multiPartCount);
 
-            testMessageBody((MimeBodyPart) multiPart.getBodyPart(0));
-            htmlMessageBody((MimeBodyPart) multiPart.getBodyPart(1));
-            testAttachment1((MimeBodyPart) multiPart.getBodyPart(2));
-            testAttachment2((MimeBodyPart) multiPart.getBodyPart(3));
-            testAttachment3((MimeBodyPart) multiPart.getBodyPart(4));
-            testAttachment4((MimeBodyPart) multiPart.getBodyPart(5));
-            testAttachment5((MimeBodyPart) multiPart.getBodyPart(6));
-            testAttachment6((MimeBodyPart) multiPart.getBodyPart(7));
-            testAttachment7((MimeBodyPart) multiPart.getBodyPart(8));
+            testMessageBody((MimeBodyPart)
+                    ((MimeMultipart) multiPart.getBodyPart(0).getContent()).getBodyPart(0));
+            htmlMessageBody((MimeBodyPart)
+                    ((MimeMultipart) multiPart.getBodyPart(0).getContent()).getBodyPart(1));
+            testAttachment1((MimeBodyPart) multiPart.getBodyPart(1));
+            testAttachment2((MimeBodyPart) multiPart.getBodyPart(2));
+            testAttachment3((MimeBodyPart) multiPart.getBodyPart(3));
+            testAttachment4((MimeBodyPart) multiPart.getBodyPart(4));
+            testAttachment5((MimeBodyPart) multiPart.getBodyPart(5));
+            testAttachment6((MimeBodyPart) multiPart.getBodyPart(6));
+            testAttachment7((MimeBodyPart) multiPart.getBodyPart(7));
 
             assertEquals(HEADER1_VALUE, message.getHeader(HEADER1_NAME)[0]);
             assertEquals(EMAIL_FROM, message.getFrom()[0].toString());

--- a/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/SmtpEmailSendWithOptionsTest.java
+++ b/email-test-utils/src/main/java/org/ballerinalang/stdlib/email/testutils/SmtpEmailSendWithOptionsTest.java
@@ -35,6 +35,7 @@ import javax.mail.MessagingException;
 import javax.mail.Multipart;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
 import javax.mail.util.SharedByteArrayInputStream;
 
 import static org.testng.AssertJUnit.assertEquals;
@@ -101,17 +102,19 @@ public class SmtpEmailSendWithOptionsTest {
             assertTrue(message.isMimeType("multipart/*"));
             Multipart multiPart = (Multipart) message.getContent();
             int multiPartCount = multiPart.getCount();
-            assertEquals(9, multiPartCount);
+            assertEquals(8, multiPartCount);
 
-            testMessageBody((MimeBodyPart) multiPart.getBodyPart(0));
-            htmlMessageBody((MimeBodyPart) multiPart.getBodyPart(1));
-            testAttachment1((MimeBodyPart) multiPart.getBodyPart(2));
-            testAttachment2((MimeBodyPart) multiPart.getBodyPart(3));
-            testAttachment3((MimeBodyPart) multiPart.getBodyPart(4));
-            testAttachment4((MimeBodyPart) multiPart.getBodyPart(5));
-            testAttachment5((MimeBodyPart) multiPart.getBodyPart(6));
-            testAttachment6((MimeBodyPart) multiPart.getBodyPart(7));
-            testAttachment7((MimeBodyPart) multiPart.getBodyPart(8));
+            testMessageBody((MimeBodyPart)
+                    ((MimeMultipart) multiPart.getBodyPart(0).getContent()).getBodyPart(0));
+            htmlMessageBody((MimeBodyPart)
+                    ((MimeMultipart) multiPart.getBodyPart(0).getContent()).getBodyPart(1));
+            testAttachment1((MimeBodyPart) multiPart.getBodyPart(1));
+            testAttachment2((MimeBodyPart) multiPart.getBodyPart(2));
+            testAttachment3((MimeBodyPart) multiPart.getBodyPart(3));
+            testAttachment4((MimeBodyPart) multiPart.getBodyPart(4));
+            testAttachment5((MimeBodyPart) multiPart.getBodyPart(5));
+            testAttachment6((MimeBodyPart) multiPart.getBodyPart(6));
+            testAttachment7((MimeBodyPart) multiPart.getBodyPart(7));
 
             assertEquals(HEADER1_VALUE, message.getHeader(HEADER1_NAME)[0]);
             assertEquals(EMAIL_FROM, message.getFrom()[0].toString());


### PR DESCRIPTION
Remove `swan-lake` from doc URLs
Enable commented tests which were commented due to lang related errors
Remove `@untainted` from SMTP `init` methods
Set `Security.SSL` as the default value of `SmtpConfig
Make secureSocket of SmtpConfig an optional field
Resolves https://github.com/ballerina-platform/ballerina-standard-library/issues/943
Resolves https://github.com/ballerina-platform/ballerina-standard-library/issues/944
Resolves https://github.com/ballerina-platform/ballerina-standard-library/issues/950
Resolves https://github.com/ballerina-platform/ballerina-standard-library/issues/951
