### PR TITLE
Change ballerina archive extension to bala

### DIFF
--- a/email-ballerina/build.gradle
+++ b/email-ballerina/build.gradle
@@ -83,8 +83,8 @@ task copyStdlibs(type: Copy) {
     /* Standard Libraries */
     configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
-        into("repo/balo") {
-            from "${artifactExtractedPath}/balo/"
+        into("repo/bala") {
+            from "${artifactExtractedPath}/bala/"
         }
         into("repo/cache") {
             from "${artifactExtractedPath}/cache"
@@ -212,8 +212,8 @@ task ballerinaBuild {
             }
         }
         copy {
-            from file("$project.projectDir/target/balo")
-            into file("$artifactCacheParent/balo/${packageOrg}/${packageName}/${tomlVersion}")
+            from file("$project.projectDir/target/bala")
+            into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}")
         }
 
         copy {


### PR DESCRIPTION
## Purpose
> Renames the extension of the package distribution file from balo to bala 
> Fixes ballerina-platform/ballerina-lang#28476 