### PR TITLE
Add Codecov Report Generation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -40,6 +40,8 @@ jobs:
           name: Code Coverage JSON
           path: email-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Dispatch Dependent Module Builds
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,6 +33,8 @@ jobs:
           name: Code Coverage JSON
           path: email-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
 
   windows-build:
     runs-on: windows-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 fixes:
-  - "ballerina/mime/*/::mime-ballerina/"
+  - "ballerina/email/*/::email-ballerina/"
 
 ignore:
   - "**/tests"
-  - "**/email-test-utils"
+  - "/email-test-utils"

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ fixes:
 
 ignore:
   - "**/tests"
-  - "/email-test-utils"
+  - "email-test-utils"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  require_ci_to_pass: no
+
 fixes:
   - "ballerina/email/*/::email-ballerina/"
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ fixes:
 ignore:
   - "**/tests"
   - "email-test-utils"
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+fixes:
+  - "ballerina/mime/*/::mime-ballerina/"
+
+ignore:
+  - "**/tests"
+  - "**/email-test-utils"


### PR DESCRIPTION
## Purpose
- Introducing `Codecov` code coverage report publishing to the `email` repository

## Goals
- Publishing the testerina generated code coverage xml to `Codecov` triggered via GitHub action of PR.

## Approach
- A new job is inserted to `Pull request` and `Build` GitHub actions that publishes the XML report to  `Codecov`.
- These jobs trigger on push or pull request and `CodeCov` generates a descriptive code coverage report.
- `Codecov` also adds comments to any PR made based on the code coverage changes between commits

## Test environment
> Ubuntu 20.04
