### PR TITLE
Set flag to enable Jacoco Coverage XML generation

### DIFF
--- a/email-ballerina/build.gradle
+++ b/email-ballerina/build.gradle
@@ -164,7 +164,7 @@ def needSeparateTest = false
 def needBuildWithTest = false
 def needPublishToCentral = false
 def needPublishToLocalCentral = false
-def testCoverageParam = "--code-coverage --includes=org.ballerinalang.stdlib.email.*:ballerina.email.*"
+def testCoverageParam = "--code-coverage --jacoco-xml --includes=org.ballerinalang.stdlib.email.*:ballerina.email.*"
 
 task initializeVariables {
     if (project.hasProperty("groups")) {


### PR DESCRIPTION
Set flag to enable Jacoco Coverage XML generation. Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30381