### PR TITLE
Block `readonly` typed `email:Message` type in the email listener

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
  - [[#1574] Avoid POP listener continuously receiving the same email message](https://github.com/ballerina-platform/ballerina-standard-library/issues/1574)
  - [[#2055] Remove Java stacktrace getting logged while Ballerina code execution](https://github.com/ballerina-platform/ballerina-standard-library/issues/2055)
  - [[#1162] Automatically set the attachment file name from the attachment file path](https://github.com/ballerina-platform/ballerina-standard-library/issues/1162)
+ - [[#2633] `readonly & email:Message` type is accepted from the email listener](https://github.com/ballerina-platform/ballerina-standard-library/issues/2633)
 
 ### Changed
  - [[#2398] Mark Service type as distinct](https://github.com/ballerina-platform/ballerina-standard-library/issues/2398)

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/email/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/email/compiler/CompilerPluginTest.java
@@ -158,6 +158,14 @@ public class CompilerPluginTest {
     }
 
     @Test
+    public void testReadonlyParameterPath() {
+        Package currentPackage = loadPackage("sample_package_12");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errors().size(), 2);
+    }
+
+    @Test
     public void testListenerPreDeclaredListener() {
         Package currentPackage = loadPackage("sample_package_10");
         PackageCompilation compilation = currentPackage.getCompilation();

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_12/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_12/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "email_test"
+name = "sample_12"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_12/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_12/service.bal
@@ -1,0 +1,49 @@
+import ballerina/email;
+
+service "testReadonlyPopService" on new email:PopListener({
+                                    host: "pop.example.com",
+                                    username: "abc@example.com",
+                                    password: "pass123",
+                                    pollingInterval: 2,
+                                    port: 995
+                                }) {
+
+    remote function onMessage(readonly & email:Message emailMessage) {
+
+    }
+
+    remote function onError(email:Error emailError) {
+
+    }
+
+    remote function onClose(email:Error? closeError) {
+
+    }
+
+}
+
+service "testReadonlyImapService" on new email:ImapListener({
+                                    host: "imap.example.com",
+                                    username: "abc@example.com",
+                                    password: "pass123",
+                                    pollingInterval: 2,
+                                    port: 993
+                                }) {
+
+    remote function onMessage(readonly & email:Message emailMessage) {
+
+    }
+
+    remote function onError(email:Error emailError) {
+
+    }
+
+    remote function onClose(email:Error? closeError) {
+
+    }
+
+    function prepareEmail() {
+
+    }
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/email/compiler/EmailServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/email/compiler/EmailServiceValidator.java
@@ -18,7 +18,10 @@
 
 package io.ballerina.stdlib.email.compiler;
 
+import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -208,7 +211,7 @@ public class EmailServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCon
             if (hasNoParameters(parameterNodes, functionDefinitionNode, functionName)) {
                 return;
             }
-            validateParameter(parameterNodes, functionName);
+            validateParameter(functionDefinitionNode, parameterNodes, functionName);
             validateFunctionReturnTypeDesc(functionDefinitionNode, functionName);
         }
     }
@@ -248,13 +251,13 @@ public class EmailServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCon
         return false;
     }
 
-    private void validateParameter(SeparatedNodeList<ParameterNode> parameterNodes, String functionName) {
+    private void validateParameter(FunctionDefinitionNode functionDefinitionNode,
+                                   SeparatedNodeList<ParameterNode> parameterNodes, String functionName) {
         for (ParameterNode parameterNode : parameterNodes) {
             RequiredParameterNode requiredParameterNode = (RequiredParameterNode) parameterNode;
             Node parameterTypeName = requiredParameterNode.typeName();
             DiagnosticInfo diagnosticInfo;
-            if (functionName.equals(ON_MESSAGE) && (!parameterTypeName.toString().contains(EMAIL_MESSAGE)
-                    || !parameterTypeName.toString().contains(MODULE_NAME))) {
+            if (functionName.equals(ON_MESSAGE) && !validateOnMessageParams(functionDefinitionNode)) {
                 diagnosticInfo = new DiagnosticInfo(CODE_104,
                         INVALID_PARAMETER_0_PROVIDED_FOR_1_FUNCTION_EXPECTS_2, DiagnosticSeverity.ERROR);
                 ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo,
@@ -274,6 +277,24 @@ public class EmailServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCon
                         modulePrefix + ERROR));
             }
         }
+    }
+
+    private boolean validateOnMessageParams(FunctionDefinitionNode functionDefinitionNode) {
+        FunctionTypeSymbol functionTypeSymbol = ((MethodSymbol) ctx.semanticModel().symbol(functionDefinitionNode)
+                .get()).typeDescriptor();
+        List<ParameterSymbol> inputParams = functionTypeSymbol.params().get();
+        String moduleId = getModuleId(inputParams.get(0));
+        String typeDescriptorSignature = inputParams.get(0).typeDescriptor().signature();
+        return typeDescriptorSignature.equals(moduleId + ":" + EMAIL_MESSAGE);
+    }
+
+    private String getModuleId(ParameterSymbol inputParam) {
+        String moduleId = modulePrefix;
+        if (inputParam.typeDescriptor().typeKind() == TypeDescKind.TYPE_REFERENCE
+                || inputParam.typeDescriptor().typeKind() == TypeDescKind.ERROR) {
+            moduleId = inputParam.typeDescriptor().getModule().get().id().toString();
+        }
+        return moduleId;
     }
 
     private void validateFunctionReturnTypeDesc(FunctionDefinitionNode functionDefinitionNode, String functionName) {


### PR DESCRIPTION
## Purpose
Resolves https://github.com/ballerina-platform/ballerina-standard-library/issues/2633

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
