### PR TITLE
Remove the ZIP URL in the load test trigger action

### DIFF
--- a/.github/workflows/trigger-load-tests.yml
+++ b/.github/workflows/trigger-load-tests.yml
@@ -60,4 +60,4 @@ jobs:
           repo: ballerina-platform/ballerina-performance-cloud
           ref: refs/heads/main
           token: ${{ secrets.BALLERINA_BOT_TOKEN }}
-          inputs: '{ "repo-name": "module-ballerina-email", "tests": "${{ steps.formatTestNames.outputs.testNames }}", "zipURL": ${{ steps.setRuntimeUrl.outputs.runtimeUrl}}, "clusterName": "${{ steps.processClusterName.outputs.clusterName }}", "dispatchType": "email-load-test" }'
+          inputs: '{ "repo-name": "module-ballerina-email", "tests": "${{ steps.formatTestNames.outputs.testNames }}", "clusterName": "${{ steps.processClusterName.outputs.clusterName }}", "dispatchType": "email-load-test" }'

--- a/load-tests/smtp_client/results/summary.csv
+++ b/load-tests/smtp_client/results/summary.csv
@@ -1,2 +1,1 @@
 Label,# Samples,Average,Median,90% Line,95% Line,99% Line,Min,Max,Error %,Throughput,Received KB/sec,Std. Dev.,Date,Payload,Users
-


### PR DESCRIPTION
## Purpose
> $subject

In the load test we are using an HTTP service as a back-end. But email module does not depends on HTTP and hence the intermediate distribution pack retrieved from the email module does not contain dependencies related to HTTP. So that we need to use the knightly distribution build.

Similar to the change [#476](https://github.com/ballerina-platform/module-ballerina-io/pull/476) in IO module.

## Examples
N/A

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
