### PR TITLE
[FIX] Sending emails with HTML content using SMTP Client

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "email"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Ballerina"]
 keywords = ["email", "SMTP", "POP", "POP3", "IMAP", "mail"]
 repository = "https://github.com/ballerina-platform/module-ballerina-email"
@@ -22,8 +22,8 @@ path = "./lib/mimepull-1.9.11.jar"
 path = "./lib/testng-7.4.0.jar"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/email-native-2.2.2.jar"
+path = "../native/build/libs/email-native-2.2.3-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "../test-utils/build/libs/email-test-utils-2.2.2.jar"
+path = "../test-utils/build/libs/email-test-utils-2.2.3-SNAPSHOT.jar"
 scope = "testOnly"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "email-compiler-plugin"
 class = "io.ballerina.stdlib.email.compiler.EmailCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/email-compiler-plugin-2.2.2.jar"
+path = "../compiler-plugin/build/libs/email-compiler-plugin-2.2.3-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -12,6 +12,8 @@ name = "email"
 version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "task"},
@@ -44,6 +46,30 @@ name = "lang.int"
 version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.runtime"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.string"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.string", moduleName = "lang.string"}
 ]
 
 [[package]]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -12,8 +12,6 @@ name = "email"
 version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.runtime"},
-	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "task"},
@@ -46,30 +44,6 @@ name = "lang.int"
 version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.runtime"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.string"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.string", moduleName = "lang.string"}
 ]
 
 [[package]]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -9,9 +9,10 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "email"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
@@ -45,6 +46,18 @@ name = "lang.int"
 version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.runtime"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
 ]
 
 [[package]]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -12,7 +12,6 @@ name = "email"
 version = "2.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
@@ -46,18 +45,6 @@ name = "lang.int"
 version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.runtime"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
 ]
 
 [[package]]

--- a/ballerina/tests/SmtpComplexEmailSend.bal
+++ b/ballerina/tests/SmtpComplexEmailSend.bal
@@ -168,7 +168,7 @@ function testSendEmailWithHtmlBody() returns error? {
         security: START_TLS_AUTO
     };
 
-    SmtpClient smtpClient = check new (host, username,  password, smtpConfig);
+    SmtpClient smtpClient = check new(host, username,  password, smtpConfig);
 
     Message email = {
         to: toAddresses,

--- a/ballerina/tests/SmtpComplexEmailSend.bal
+++ b/ballerina/tests/SmtpComplexEmailSend.bal
@@ -193,6 +193,52 @@ function testSendEmailWithHtmlBody() returns error? {
         testSendEmailWithHtmlBody
     ]
 }
+function testSendEmailWithTextAndHtmlBody() returns error? {
+    string host = "127.0.0.1";
+    string username = "hascode";
+    string password = "abcdef123";
+    string subject = "Test E-Mail for Text and HTML Content";
+    string body = "This is a test e-mail.";
+    string htmlBody = "<h1>This message is embedded in HTML tags.</h1>";
+    string contentType = "text/html";
+    string fromAddress = "someone1@localhost.com";
+    string sender = "someone2@localhost.com";
+    string[] toAddresses = ["hascode1@localhost", "hascode2@localhost"];
+    string[] ccAddresses = ["hascode3@localhost", "hascode4@localhost"];
+    string[] bccAddresses = ["hascode5@localhost", "hascode6@localhost"];
+    string[] replyToAddresses = ["reply1@abc.com", "reply2@abc.com"];
+
+    SmtpConfiguration smtpConfig = {
+        port: 3025,
+        security: START_TLS_AUTO
+    };
+
+    SmtpClient smtpClient = check new(host, username,  password, smtpConfig);
+
+    Message email = {
+        to: toAddresses,
+        cc: ccAddresses,
+        bcc: bccAddresses,
+        subject: subject,
+        body: body,
+        htmlBody: htmlBody,
+        contentType: contentType,
+        headers: {header1_name: "header1_value"},
+        'from: fromAddress,
+        sender: sender,
+        replyTo: replyToAddresses
+    };
+
+    _ = check smtpClient->sendMessage(email);
+    _ = check validateEmailsWithHtmlAndTextBodies();
+}
+
+@test:Config {
+    groups: ["complexEmails"],
+    dependsOn: [
+        testSendEmailWithHtmlBody
+    ]
+}
 function testSendEmailWithoutBody() returns error? {
     string host = "127.0.0.1";
     string username = "hascode";
@@ -241,5 +287,9 @@ public function validateComplexEmails() returns Error? = @java:Method {
 } external;
 
 public function validateEmailsWithHtmlBodies() returns Error? = @java:Method {
+    'class: "io.ballerina.stdlib.email.testutils.SmtpComplexEmailSendTest"
+} external;
+
+public function validateEmailsWithHtmlAndTextBodies() returns Error? = @java:Method {
     'class: "io.ballerina.stdlib.email.testutils.SmtpComplexEmailSendTest"
 } external;

--- a/ballerina/tests/SmtpComplexEmailSend.bal
+++ b/ballerina/tests/SmtpComplexEmailSend.bal
@@ -149,6 +149,7 @@ function testSendComplexEmail() returns error? {
         testSendComplexEmail
     ]
 }
+
 function testSendEmailWithHtmlBody() returns error? {
     string host = "127.0.0.1";
     string username = "hascode";

--- a/ballerina/tests/SmtpComplexEmailSend.bal
+++ b/ballerina/tests/SmtpComplexEmailSend.bal
@@ -153,7 +153,7 @@ function testSendEmailWithHtmlBody() returns error? {
     string host = "127.0.0.1";
     string username = "hascode";
     string password = "abcdef123";
-    string subject = "Test E-Mail";
+    string subject = "Test E-Mail for HTML Content";
     string htmlBody = "<h1>This message is embedded in HTML tags.</h1>";
     string contentType = "text/html";
     string fromAddress = "someone1@localhost.com";

--- a/ballerina/tests/SmtpComplexEmailSend.bal
+++ b/ballerina/tests/SmtpComplexEmailSend.bal
@@ -149,6 +149,50 @@ function testSendComplexEmail() returns error? {
         testSendComplexEmail
     ]
 }
+function testSendEmailWithHtmlBody() returns error? {
+    string host = "127.0.0.1";
+    string username = "hascode";
+    string password = "abcdef123";
+    string subject = "Test E-Mail";
+    string htmlBody = "<h1>This message is embedded in HTML tags.</h1>";
+    string contentType = "text/html";
+    string fromAddress = "someone1@localhost.com";
+    string sender = "someone2@localhost.com";
+    string[] toAddresses = ["hascode1@localhost", "hascode2@localhost"];
+    string[] ccAddresses = ["hascode3@localhost", "hascode4@localhost"];
+    string[] bccAddresses = ["hascode5@localhost", "hascode6@localhost"];
+    string[] replyToAddresses = ["reply1@abc.com", "reply2@abc.com"];
+
+    SmtpConfiguration smtpConfig = {
+        port: 3025,
+        security: START_TLS_AUTO
+    };
+
+    SmtpClient smtpClient = check new (host, username,  password, smtpConfig);
+
+    Message email = {
+        to: toAddresses,
+        cc: ccAddresses,
+        bcc: bccAddresses,
+        subject: subject,
+        htmlBody: htmlBody,
+        contentType: contentType,
+        headers: {header1_name: "header1_value"},
+        'from: fromAddress,
+        sender: sender,
+        replyTo: replyToAddresses
+    };
+
+    _ = check smtpClient->sendMessage(email);
+    _ = check validateEmailsWithHtmlBodies();
+}
+
+@test:Config {
+    groups: ["complexEmails"],
+    dependsOn: [
+        testSendEmailWithHtmlBody
+    ]
+}
 function testSendEmailWithoutBody() returns error? {
     string host = "127.0.0.1";
     string username = "hascode";
@@ -193,5 +237,9 @@ public function stopComplexSmtpServer() returns Error? = @java:Method {
 } external;
 
 public function validateComplexEmails() returns Error? = @java:Method {
+    'class: "io.ballerina.stdlib.email.testutils.SmtpComplexEmailSendTest"
+} external;
+
+public function validateEmailsWithHtmlBodies() returns Error? = @java:Method {
     'class: "io.ballerina.stdlib.email.testutils.SmtpComplexEmailSendTest"
 } external;

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Fixed
+- [[#2778] Could not able to send html template as the email body](https://github.com/ballerina-platform/ballerina-standard-library/issues/2778)
+
+## [2.2.2] - 2022-03-09
+
+### Fixed
 - [[#2739] Error when optional body not present in sendMessage of email module](https://github.com/ballerina-platform/ballerina-standard-library/issues/2739)
 
 ## [0.2.0-beta.1] - 2021-06-02

--- a/test-utils/src/main/java/io/ballerina/stdlib/email/testutils/SmtpComplexEmailSendTest.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/email/testutils/SmtpComplexEmailSendTest.java
@@ -67,9 +67,10 @@ public class SmtpComplexEmailSendTest {
     private static final String EMAIL_FROM = "someone1@localhost.com";
     private static final String EMAIL_SENDER = "someone2@localhost.com";
     private static final String EMAIL_SUBJECT = "Test E-Mail";
+    private static final String EMAIL_SUBJECT_HTML_ONLY = "Test E-Mail for HTML Content";
     private static final String EMAIL_TEXT = "This is a test e-mail.";
     private static final String EMAIL_HTML = "<h1>This message is embedded in HTML tags.</h1>";
-    private static final String EMAIL_CONTENT_TYPE = "text/html";
+    private static final String HTML_CONTENT_TYPE = "text/html";
     private static final String HEADER1_NAME = "header1_name";
     private static final String HEADER1_VALUE = "header1_value";
     private static final String[] EMAIL_TO_ADDRESSES = {"hascode1@localhost", "hascode2@localhost"};
@@ -133,6 +134,24 @@ public class SmtpComplexEmailSendTest {
         return null;
     }
 
+    public static Object validateEmailsWithHtmlBodies() {
+        MimeMessage[] messages = mailServer.getReceivedMessages();
+        assertNotNull(messages);
+        for (MimeMessage currentMessage: messages) {
+            try {
+                if (!EMAIL_SUBJECT_HTML_ONLY.equals(currentMessage.getSubject())) {
+                    continue;
+                }
+                assertEquals(HTML_CONTENT_TYPE, currentMessage.getContentType());
+                assertEquals(EMAIL_HTML, currentMessage.getContent());
+            } catch (MessagingException | IOException e) {
+                return CommonUtil.getBallerinaError(EmailConstants.ERROR,
+                        "Error while validating the complex email: " + e.getMessage());
+            }
+        }
+        return null;
+    }
+
     private static void testMessageBody(MimeBodyPart bodyPart) throws IOException, MessagingException {
         assertEquals(EMAIL_TEXT, ((String) bodyPart.getContent()));
         assertTrue(bodyPart.getContentType().startsWith(MimeConstants.TEXT_PLAIN));
@@ -140,7 +159,7 @@ public class SmtpComplexEmailSendTest {
 
     private static void htmlMessageBody(MimeBodyPart bodyPart) throws IOException, MessagingException {
         assertEquals(EMAIL_HTML, ((String) bodyPart.getContent()));
-        assertTrue(bodyPart.getContentType().startsWith(EMAIL_CONTENT_TYPE));
+        assertTrue(bodyPart.getContentType().startsWith(HTML_CONTENT_TYPE));
     }
 
     private static void testAttachment1(MimeBodyPart bodyPart) throws IOException, MessagingException {

--- a/test-utils/src/main/java/io/ballerina/stdlib/email/testutils/SmtpComplexEmailSendTest.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/email/testutils/SmtpComplexEmailSendTest.java
@@ -142,8 +142,8 @@ public class SmtpComplexEmailSendTest {
                 if (!EMAIL_SUBJECT_HTML_ONLY.equals(currentMessage.getSubject())) {
                     continue;
                 }
-                assertEquals(HTML_CONTENT_TYPE, currentMessage.getContentType());
-                assertEquals(EMAIL_HTML, currentMessage.getContent());
+                assertTrue(currentMessage.getContentType().startsWith(HTML_CONTENT_TYPE));
+                assertEquals(EMAIL_HTML, ((String) currentMessage.getContent()).trim());
             } catch (MessagingException | IOException e) {
                 return CommonUtil.getBallerinaError(EmailConstants.ERROR,
                         "Error while validating the complex email: " + e.getMessage());

--- a/test-utils/src/main/java/io/ballerina/stdlib/email/testutils/SmtpComplexEmailSendTest.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/email/testutils/SmtpComplexEmailSendTest.java
@@ -68,6 +68,7 @@ public class SmtpComplexEmailSendTest {
     private static final String EMAIL_SENDER = "someone2@localhost.com";
     private static final String EMAIL_SUBJECT = "Test E-Mail";
     private static final String EMAIL_SUBJECT_HTML_ONLY = "Test E-Mail for HTML Content";
+    private static final String EMAIL_SUBJECT_HTML_AND_TEXT = "Test E-Mail for Text and HTML Content";
     private static final String EMAIL_TEXT = "This is a test e-mail.";
     private static final String EMAIL_HTML = "<h1>This message is embedded in HTML tags.</h1>";
     private static final String HTML_CONTENT_TYPE = "text/html";
@@ -137,19 +138,52 @@ public class SmtpComplexEmailSendTest {
     public static Object validateEmailsWithHtmlBodies() {
         MimeMessage[] messages = mailServer.getReceivedMessages();
         assertNotNull(messages);
-        for (MimeMessage currentMessage: messages) {
-            try {
+        try {
+            assertTrue(isMessageAvailable(EMAIL_SUBJECT_HTML_ONLY, messages));
+            for (MimeMessage currentMessage : messages) {
                 if (!EMAIL_SUBJECT_HTML_ONLY.equals(currentMessage.getSubject())) {
                     continue;
                 }
                 assertTrue(currentMessage.getContentType().startsWith(HTML_CONTENT_TYPE));
                 assertEquals(EMAIL_HTML, ((String) currentMessage.getContent()).trim());
-            } catch (MessagingException | IOException e) {
-                return CommonUtil.getBallerinaError(EmailConstants.ERROR,
-                        "Error while validating the complex email: " + e.getMessage());
             }
+        } catch (MessagingException | IOException e) {
+            return CommonUtil.getBallerinaError(EmailConstants.ERROR,
+                    "Error while validating the complex email: " + e.getMessage());
         }
         return null;
+    }
+
+    public static Object validateEmailsWithHtmlAndTextBodies() {
+        MimeMessage[] messages = mailServer.getReceivedMessages();
+        assertNotNull(messages);
+        try {
+            assertTrue(isMessageAvailable(EMAIL_SUBJECT_HTML_AND_TEXT, messages));
+            for (MimeMessage currentMessage : messages) {
+                if (!EMAIL_SUBJECT_HTML_AND_TEXT.equals(currentMessage.getSubject())) {
+                    continue;
+                }
+                assertTrue(currentMessage.isMimeType("multipart/*"));
+                Multipart multiPart = (Multipart) currentMessage.getContent();
+                int multiPartCount = multiPart.getCount();
+                assertEquals(2, multiPartCount);
+                testMessageBody((MimeBodyPart) multiPart.getBodyPart(0));
+                htmlMessageBody((MimeBodyPart) multiPart.getBodyPart(1));
+            }
+        } catch (MessagingException | IOException e) {
+            return CommonUtil.getBallerinaError(EmailConstants.ERROR,
+                    "Error while validating the complex email: " + e.getMessage());
+        }
+        return null;
+    }
+
+    private static boolean isMessageAvailable(String subject, MimeMessage[] messages) throws MessagingException {
+        for (MimeMessage currentMessage: messages) {
+            if (subject.equals(currentMessage.getSubject())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static void testMessageBody(MimeBodyPart bodyPart) throws IOException, MessagingException {


### PR DESCRIPTION
## Purpose
> $subject

Due to a logic issue in SMTP client, the email body is set to empty-string when sending an email with HTML body. This PR will fix the related SMTP client logic.

Fixes [#2778](https://github.com/ballerina-platform/ballerina-standard-library/issues/2778)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec
