### PR TITLE
Fix issue with content-type resolving with html-body

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "email"
-version = "2.2.3"
+version = "2.2.4"
 authors = ["Ballerina"]
 keywords = ["email", "SMTP", "POP", "POP3", "IMAP", "mail"]
 repository = "https://github.com/ballerina-platform/module-ballerina-email"
@@ -22,8 +22,8 @@ path = "./lib/mimepull-1.9.11.jar"
 path = "./lib/testng-7.4.0.jar"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/email-native-2.2.3.jar"
+path = "../native/build/libs/email-native-2.2.4-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "../test-utils/build/libs/email-test-utils-2.2.3.jar"
+path = "../test-utils/build/libs/email-test-utils-2.2.4-SNAPSHOT.jar"
 scope = "testOnly"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "email-compiler-plugin"
 class = "io.ballerina.stdlib.email.compiler.EmailCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/email-compiler-plugin-2.2.3.jar"
+path = "../compiler-plugin/build/libs/email-compiler-plugin-2.2.4-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -9,11 +9,9 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "email"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.runtime"},
-	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "task"},
@@ -46,30 +44,6 @@ name = "lang.int"
 version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.runtime"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.string"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.string", moduleName = "lang.string"}
 ]
 
 [[package]]
@@ -110,7 +84,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/smtp_client_endpoint.bal
+++ b/ballerina/smtp_client_endpoint.bal
@@ -40,11 +40,9 @@ public isolated client class SmtpClient {
     # + email - An `email:Message` message, which needs to be sent to the recipient
     # + return - An `email:Error` if failed to send the message to the recipient or else `()`
     remote isolated function sendMessage(Message email) returns Error? {
-        if (email?.contentType == ()) {
-            email.contentType = "text/plain";
-        } else if (!self.containsType(email?.contentType, "text")) {
+        if email.contentType is string && !self.containsType(email?.contentType, "text") {
             return error Error("Content type of the email should be text.");
-        }
+        } 
         self.putAttachmentToArray(email);
         return send(self, email);
     }

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Fixed
+- [[#2820] Html content sends as raw text if content type is not provided](https://github.com/ballerina-platform/ballerina-standard-library/issues/2820)
+
+## [2.2.3] - 2022-03-23
+
+### Fixed
 - [[#2778] Could not able to send html template as the email body](https://github.com/ballerina-platform/ballerina-standard-library/issues/2778)
 - [[#2777] IMAP listener could not properly identify the content-type of the received emails](https://github.com/ballerina-platform/ballerina-standard-library/issues/2777)
 


### PR DESCRIPTION
## Purpose
> $subject

Fixes [#2820](https://github.com/ballerina-platform/ballerina-standard-library/issues/2820)

## Examples
Following code-sample should send a email with HTML body.
```ballerina
import ballerina/io;
import ballerina/email;

public function main() returns error? {
    email:SmtpClient smtpClient = check new ("[smtp.gmail.com](http://smtp.gmail.com/)", "", ""); // removed username and password

    email:Message email = {
        to: "", // removed the email
        'from: "", // removed the email
        subject: "Sample Email 3",
        htmlBody: "<html><head><title>Example</title></head><body><p>This is an example of a simple HTML page with one paragraph.</p></body></html>"
    };

    email:Error? response = check smtpClient->sendMessage(email);
    io:println(response);
}
```

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [ ] ~Updated the spec~
