### PR TITLE
Add support for allow sending emails without auth in SMTP client

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "email"
-version = "2.12.1"
+version = "2.13.0"
 authors = ["Ballerina"]
 keywords = ["email", "SMTP", "POP", "POP3", "IMAP", "mail"]
 repository = "https://github.com/ballerina-platform/module-ballerina-email"
@@ -39,12 +39,12 @@ path = "./lib/activation-1.1.1.jar"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "email-native"
-version = "2.12.1"
-path = "../native/build/libs/email-native-2.12.1-SNAPSHOT.jar"
+version = "2.13.0"
+path = "../native/build/libs/email-native-2.13.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "email-test-utils"
-version = "2.12.1"
-path = "../test-utils/build/libs/email-test-utils-2.12.1-SNAPSHOT.jar"
+version = "2.13.0"
+path = "../test-utils/build/libs/email-test-utils-2.13.0-SNAPSHOT.jar"
 scope = "testOnly"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "email-compiler-plugin"
 class = "io.ballerina.stdlib.email.compiler.EmailCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/email-compiler-plugin-2.12.1-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/email-compiler-plugin-2.13.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "email"
-version = "2.12.1"
+version = "2.13.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.runtime"},

--- a/ballerina/smtp_client_endpoint.bal
+++ b/ballerina/smtp_client_endpoint.bal
@@ -23,13 +23,19 @@ public isolated client class SmtpClient {
     # Gets invoked during the `email:SmtpClient` initialization.
     #
     # + host - Host of the SMTP Client
-    # + username - Username of the SMTP Client
-    # + password - Password of the SMTP Client
+    # + username - Username of the SMTP Client if authentication is required
+    # + password - Password of the SMTP Client if authentication is required
     # + clientConfig - Configurations for SMTP Client
     # + return - An `email:Error` if failed to initialize or else `()`
-    public isolated function init(string host, string username, string password, *SmtpConfiguration clientConfig)
-            returns Error? {
-        return initSmtpClientEndpoint(self, host, username, password, clientConfig);
+    public isolated function init(string host, string? username = (), string? password = (),
+            *SmtpConfiguration clientConfig) returns Error? {
+        if username is string && password is string {
+            return initSmtpClientEndpoint(self, host, username, password, clientConfig);
+        }
+        if username is () && password is () {
+            return initNoAuthSmtpClientEndpoint(self, host, clientConfig);
+        }
+        return error Error("Mismatched input: 'username' and 'password' must either both be set or both be ().");
     }
 
     # Sends an email message.
@@ -42,7 +48,7 @@ public isolated client class SmtpClient {
     remote isolated function sendMessage(Message email) returns Error? {
         if email.contentType is string && !self.containsType(email?.contentType, "text") {
             return error Error("Content type of the email should be text.");
-        } 
+        }
         self.putAttachmentToArray(email);
         return send(self, email);
     }
@@ -58,8 +64,7 @@ public isolated client class SmtpClient {
     # + from - From address
     # + body - Text body of the email
     # + options - Optional parameters of the email
-    # + return - An `email:Error` if failed to send the message to
-    #            the recipient or else `()`
+    # + return - An `email:Error` if failed to send the message to the recipient or else `()`
     remote isolated function send(string|string[] to, string subject, string 'from, string body, *Options options)
             returns Error? {
         Message email = {
@@ -123,13 +128,18 @@ public isolated client class SmtpClient {
 
 isolated function initSmtpClientEndpoint(SmtpClient clientEndpoint, string host, string username, string password,
         SmtpConfiguration config) returns Error? = @java:Method {
-    name : "initClientEndpoint",
-    'class : "io.ballerina.stdlib.email.client.SmtpClient"
+    name: "initClientEndpoint",
+    'class: "io.ballerina.stdlib.email.client.SmtpClient"
+} external;
+
+isolated function initNoAuthSmtpClientEndpoint(SmtpClient clientEndpoint, string host, SmtpConfiguration config)
+returns Error? = @java:Method {
+    'class: "io.ballerina.stdlib.email.client.SmtpClient"
 } external;
 
 isolated function send(SmtpClient clientEndpoint, Message email) returns Error? = @java:Method {
-    name : "sendMessage",
-    'class : "io.ballerina.stdlib.email.client.SmtpClient"
+    name: "sendMessage",
+    'class: "io.ballerina.stdlib.email.client.SmtpClient"
 } external;
 
 # Configuration of the SMTP Endpoint.

--- a/ballerina/tests/SmtpNoAuthEmailSend.bal
+++ b/ballerina/tests/SmtpNoAuthEmailSend.bal
@@ -1,0 +1,198 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/jballerina.java;
+import ballerina/test;
+
+@test:BeforeGroups {
+    value: ["no_auth"]
+}
+function beforeNoAuthEmailTests() returns error? {
+    check startNoAuthSmtpServer();
+}
+
+@test:AfterGroups {
+    value: ["no_auth"]
+}
+function afterNoAuthEmailTests() returns error? {
+    check stopNoAuthSmtpServer();
+}
+
+@test:Config {
+    groups: ["smtp", "no_auth"]
+}
+function testSendSimpleEmailWithoutAuth() returns error? {
+    string host = "127.0.0.1";
+    string toAddress = "hascode@localhost";
+    string subject = "Test E-Mail Without Auth";
+    string body = "This is a test e-mail sent without authentication.";
+    string fromAddress = "someone@localhost.com";
+
+    SmtpConfiguration smtpConfig = {
+        port: 3026,
+        security: START_TLS_AUTO
+    };
+
+    SmtpClient smtpClient = check new (host, clientConfig = smtpConfig);
+
+    Message email = {
+        to: toAddress,
+        subject,
+        body,
+        'from: fromAddress
+    };
+
+    check smtpClient->sendMessage(email);
+    check validateNoAuthEmail();
+}
+
+@test:Config {
+    groups: ["smtp", "no_auth"],
+    dependsOn: [testSendSimpleEmailWithoutAuth]
+}
+function testSendEmailWithoutAuthUsingRemoteFunction() returns error? {
+    string host = "127.0.0.1";
+    string toAddress = "hascode@localhost";
+    string subject = "Test E-Mail Without Auth - Remote";
+    string body = "This is a test e-mail sent using remote send function without authentication.";
+    string fromAddress = "someone@localhost.com";
+
+    SmtpConfiguration smtpConfig = {
+        port: 3026,
+        security: START_TLS_AUTO
+    };
+    SmtpClient smtpClient = check new (host, clientConfig = smtpConfig);
+    check smtpClient->send(toAddress, subject, fromAddress, body);
+}
+
+@test:Config {
+    groups: ["smtp", "no_auth"],
+    dependsOn: [testSendEmailWithoutAuthUsingRemoteFunction]
+}
+function testSendComplexEmailWithoutAuth() returns error? {
+    string host = "127.0.0.1";
+    string subject = "Test Complex E-Mail Without Auth";
+    string body = "This is a test e-mail.";
+    string htmlBody = "<h1>This message is embedded in HTML tags.</h1>";
+    string contentType = "text/html";
+    string fromAddress = "someone1@localhost.com";
+    string sender = "someone2@localhost.com";
+    string[] toAddresses = ["hascode1@localhost", "hascode2@localhost"];
+    string[] ccAddresses = ["hascode3@localhost", "hascode4@localhost"];
+    string[] bccAddresses = ["hascode5@localhost", "hascode6@localhost"];
+    string[] replyToAddresses = ["reply1@abc.com", "reply2@abc.com"];
+
+    SmtpConfiguration smtpConfig = {
+        port: 3026,
+        security: START_TLS_AUTO
+    };
+
+    SmtpClient smtpClient = check new (host, clientConfig = smtpConfig);
+
+    Message email = {
+        to: toAddresses,
+        cc: ccAddresses,
+        bcc: bccAddresses,
+        subject,
+        body,
+        htmlBody: htmlBody,
+        contentType,
+        headers: {header1_name: "header1_value"},
+        'from: fromAddress,
+        sender,
+        replyTo: replyToAddresses
+    };
+
+    check smtpClient->sendMessage(email);
+}
+
+@test:Config {
+    groups: ["smtp", "no_auth"],
+    dependsOn: [testSendComplexEmailWithoutAuth]
+}
+function testSendEmailWithoutAuthWithOptions() returns error? {
+    string host = "127.0.0.1";
+    string toAddress = "hascode@localhost";
+    string subject = "Test E-Mail Without Auth - With Options";
+    string body = "This is a test e-mail.";
+    string fromAddress = "someone@localhost.com";
+    string ccAddress = "cc@localhost";
+    string bccAddress = "bcc@localhost";
+
+    SmtpConfiguration smtpConfig = {
+        port: 3026,
+        security: START_TLS_AUTO
+    };
+
+    SmtpClient smtpClient = check new (host, clientConfig = smtpConfig);
+
+    check smtpClient->send(toAddress, subject, fromAddress, body,
+        cc = ccAddress,
+        bcc = bccAddress,
+        sender = "sender@localhost.com"
+    );
+}
+
+@test:Config {}
+function testMismatchedUsernamePasswordError() returns error? {
+    string host = "127.0.0.1";
+
+    SmtpConfiguration smtpConfig = {
+        port: 3026,
+        security: START_TLS_AUTO
+    };
+
+    string expectedErrorMessage = "Mismatched input: 'username' and 'password' must either both be set or both be ().";
+
+    // Test with only username provided
+    SmtpClient|Error result1 = new (host, username = "user@localhost.com", clientConfig = smtpConfig);
+    if result1 is SmtpClient {
+        test:assertFail("Expected error when only username is provided without password");
+    }
+    test:assertEquals(result1.message(), expectedErrorMessage);
+
+    // Test with only password provided
+    SmtpClient|Error result2 = new (host, password = "password123", clientConfig = smtpConfig);
+    if result2 is SmtpClient {
+        test:assertFail("Expected error when only password is provided without username");
+    }
+    test:assertEquals(result2.message(), expectedErrorMessage);
+}
+
+@test:Config {}
+function testExplicitNullAuthParameters() returns error? {
+    string host = "127.0.0.1";
+
+    SmtpConfiguration smtpConfig = {
+        port: 3026,
+        security: START_TLS_AUTO
+    };
+
+    // Test with explicitly passing nil for both username and password
+    SmtpClient _ = check new (host, username = (), password = (), clientConfig = smtpConfig);
+}
+
+public function startNoAuthSmtpServer() returns Error? = @java:Method {
+    'class: "io.ballerina.stdlib.email.testutils.SmtpNoAuthEmailSendTest"
+} external;
+
+public function stopNoAuthSmtpServer() returns Error? = @java:Method {
+    'class: "io.ballerina.stdlib.email.testutils.SmtpNoAuthEmailSendTest"
+} external;
+
+public function validateNoAuthEmail() returns Error? = @java:Method {
+    'class: "io.ballerina.stdlib.email.testutils.SmtpNoAuthEmailSendTest"
+} external;

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@ This file contains all the notable changes done to the Ballerina Email package t
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- [Add support for allow sending emails without auth in SMTP client](https://github.com/ballerina-platform/ballerina-library/issues/8345)
+
 ## [2.12.1] - 2025-10-03
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,12 @@ This file contains all the notable changes done to the Ballerina Email package t
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.12.1] - 2025-10-03
+
+### Added
+
+- [Add support for static analysis rule for "Server hostnames should be verified during SSL/TLS connections"](https://github.com/ballerina-platform/ballerina-library/issues/8255)
+
 ### Changed
 - [Make some of the Java classes proper utility classes](https://github.com/ballerina-platform/ballerina-standard-library/issues/4918)
 

--- a/compiler-plugin-tests/src/test/resources/testng.xml
+++ b/compiler-plugin-tests/src/test/resources/testng.xml
@@ -25,7 +25,7 @@
         </classes>
     </test>
 
-    <test name="Email Compiler Plugin Tests" parallel="false">
+    <test name="Email Compiler Plugin Tests">
         <classes>
             <class name="io.ballerina.stdlib.email.compiler.staticcodeanalyzer.StaticCodeAnalyzerTest"/>
         </classes>

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -24,6 +24,8 @@ The conforming implementation of the specification is released and included in t
 3. [Client](#3-client)
     * 3.1. [SMTP Client](#31-smtp-client)
        * 3.1.1. [`init` function](#311-init-function)
+          * 3.1.1.1. [Authenticated Mode](#3111-authenticated-mode)
+          * 3.1.1.2. [Unauthenticated Mode](#3112-unauthenticated-mode)
        * 3.1.2. [`sendMessage` function](#312-sendmessage-function)
        * 3.1.3. [`send` function](#313-send-function)
     * 3.2. [POP3 Client](#32-pop3-client)
@@ -41,6 +43,8 @@ The conforming implementation of the specification is released and included in t
 5. [Samples](#5-samples)
     * 5.1. [Clients](#51-clients)
         * 5.1.1. [SMTP Client](#511-smtp-client)
+           * 5.1.1.1. [With Authentication](#5111-with-authentication)
+           * 5.1.1.2. [Without Authentication](#5112-without-authentication)
         * 5.1.2. [POP3 Client](#512-pop3-client)
         * 5.1.3. [IMAP Client](#513-imap-client)
     * 5.2. [Services](#52-services)
@@ -64,12 +68,26 @@ Sends an email to with SMTP protocol.
 Either this client can be used to send an email from a pre-defined `email:Message` record or directly sending the email by passing all the parameters as arguments.
 
 #### 3.1.1 `init` function
+
 If there are certificates to be added or in the case where the port number is different from `465` with SSL a configuration has to be passed.
-Otherwise, only the host address, username, and the password has to be provided.
+The SMTP client supports both authenticated and unauthenticated modes.
+
+##### 3.1.1.1 Authenticated Mode
+
+For authenticated SMTP servers, provide the host address, username, and password:
 
 ```ballerina
 email:SmtpClient smtpClient = check new ("smtp.email.com", "sender@email.com" , "pass123");
 ```
+
+##### 3.1.1.2 Unauthenticated Mode
+For SMTP servers that don't require authentication (e.g., internal relay servers), omit the username and password or explicitly pass `()`:
+
+```ballerina
+email:SmtpClient smtpClient = check new ("smtp.email.com");
+```
+
+> **Note:** Both `username` and `password` must either be provided together or both omitted. Providing only one will result in an error.
 
 #### 3.1.2 `sendMessage` function
 The `email:Message` record has to be defined first as follows.
@@ -206,9 +224,30 @@ When the listener is getting closed `onClose` method get called.
 ### 5.1 Clients
 
 #### 5.1.1 SMTP Client
+
+##### 5.1.1.1 With Authentication
 ```ballerina
 public function main() returns error? {
     email:SmtpClient smtpClient = check new ("smtp.email.com", "sender@email.com" , "pass123");
+    email:Message email = {
+        to: ["receiver1@email.com", "receiver2@email.com"],
+        subject: "Sample Email",
+        body: "This is a sample email.",
+        'from: "author@email.com",
+        replyTo: ["replyTo1@email.com", "replyTo2@email.com"]
+    };
+    check smtpClient->sendMessage(email);
+}
+```
+
+##### 5.1.1.2 Without Authentication
+```ballerina
+public function main() returns error? {
+    email:SmtpConfiguration smtpConfig = {
+        port: 25,
+        security: email:START_TLS_AUTO
+    };
+    email:SmtpClient smtpClient = check new ("smtp.relay.com", clientConfig = smtpConfig);
     email:Message email = {
         to: ["receiver1@email.com", "receiver2@email.com"],
         subject: "Sample Email",

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -87,7 +87,9 @@ For SMTP servers that don't require authentication (e.g., internal relay servers
 email:SmtpClient smtpClient = check new ("smtp.email.com");
 ```
 
-> **Note:** Both `username` and `password` must either be provided together or both omitted. Providing only one will result in an error.
+> **Note:**
+> - Both `username` and `password` must either be provided together or both omitted. Providing only one will result in an error.
+> - When using the unauthenticated mode, the `from` field is **mandatory** in the email message, as there is no authenticated username to fall back on.
 
 #### 3.1.2 `sendMessage` function
 The `email:Message` record has to be defined first as follows.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.12.2-SNAPSHOT
+version=2.13.0-SNAPSHOT
 slf4jVersion=1.7.30
 testngVersion=7.6.1
 javaMailVersion=1.6.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.12.1-SNAPSHOT
+version=2.12.2-SNAPSHOT
 slf4jVersion=1.7.30
 testngVersion=7.6.1
 javaMailVersion=1.6.2

--- a/native/src/main/java/io/ballerina/stdlib/email/client/SmtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/email/client/SmtpClient.java
@@ -93,9 +93,9 @@ public class SmtpClient {
      */
     public static Object sendMessage(BObject clientConnector, BMap<BString, Object> message) {
         try {
-            Transport.send(SmtpUtil.generateMessage(
-                    (Session) clientConnector.getNativeData(EmailConstants.PROPS_SESSION),
-                    (String) clientConnector.getNativeData(EmailConstants.PROPS_USERNAME.getValue()), message));
+            Session session = (Session) clientConnector.getNativeData(EmailConstants.PROPS_SESSION);
+            String username = (String) clientConnector.getNativeData(EmailConstants.PROPS_USERNAME.getValue());
+            Transport.send(SmtpUtil.generateMessage(session, username, message));
             return null;
         } catch (SendFailedException e) {
             String invalidAddresses = Arrays.stream(e.getInvalidAddresses())

--- a/native/src/main/java/io/ballerina/stdlib/email/client/SmtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/email/client/SmtpClient.java
@@ -49,29 +49,22 @@ public class SmtpClient {
 
     private static final Logger log = LoggerFactory.getLogger(SmtpClient.class);
 
-    private SmtpClient() {}
+    private SmtpClient() {
+    }
 
     /**
      * Initializes the BObject object with the SMTP Properties.
+     *
      * @param clientEndpoint Represents the SMTP Client class
-     * @param host Represents the host address of the SMTP server
-     * @param username Represents the username of the SMTP server
-     * @param password Represents the password of the SMTP server
-     * @param config Properties required to configure the SMTP Session
+     * @param host           Represents the host address of the SMTP server
+     * @param username       Represents the username of the SMTP server
+     * @param password       Represents the password of the SMTP server
+     * @param config         Properties required to configure the SMTP Session
      * @return If an error occurs in the SMTP client, error
      */
     public static Object initClientEndpoint(BObject clientEndpoint, BString host, BString username, BString password,
-                                          BMap<BString, Object> config) {
-        if (config.size() == 0) {
-            return CommonUtil.getBallerinaError(EmailConstants.ERROR, "SmtpConfiguration should not be empty.");
-        }
-        Properties properties;
-        try {
-            properties = SmtpUtil.getProperties(config, host.getValue());
-        } catch (IOException | GeneralSecurityException e) {
-            log.debug("Error while initializing SMTP properties : ", e);
-            return CommonUtil.getBallerinaError(EmailConstants.ERROR, e.getMessage());
-        }
+                                            BMap<BString, Object> config) {
+        Properties properties = getPropertiesFromConfig(host.getValue(), config, true);
         Session session = Session.getInstance(properties,
                 new javax.mail.Authenticator() {
                     protected PasswordAuthentication getPasswordAuthentication() {
@@ -83,10 +76,19 @@ public class SmtpClient {
         return null;
     }
 
+    public static Object initNoAuthSmtpClientEndpoint(BObject clientEndpoint, BString host,
+                                                      BMap<BString, Object> config) {
+        Properties properties = getPropertiesFromConfig(host.getValue(), config, false);
+        Session session = Session.getInstance(properties);
+        clientEndpoint.addNativeData(EmailConstants.PROPS_SESSION, session);
+        return null;
+    }
+
     /**
      * Sends an email to an SMTP server.
+     *
      * @param clientConnector Represents the SMTP Client class
-     * @param message Fields of an email
+     * @param message         Fields of an email
      * @return If an error occurs in the SMTP client, error
      */
     public static Object sendMessage(BObject clientConnector, BMap<BString, Object> message) {
@@ -107,4 +109,15 @@ public class SmtpClient {
         }
     }
 
+    private static Properties getPropertiesFromConfig(String host, BMap<BString, Object> config, boolean requireAuth) {
+        if (config.isEmpty()) {
+            throw CommonUtil.getBallerinaError(EmailConstants.ERROR, "SmtpConfiguration should not be empty.");
+        }
+        try {
+            return SmtpUtil.getProperties(config, host, requireAuth);
+        } catch (IOException | GeneralSecurityException e) {
+            log.debug("Error while initializing SMTP properties : ", e);
+            throw CommonUtil.getBallerinaError(EmailConstants.ERROR, e.getMessage());
+        }
+    }
 }

--- a/native/src/main/java/io/ballerina/stdlib/email/util/SmtpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/email/util/SmtpUtil.java
@@ -159,6 +159,11 @@ public final class SmtpUtil {
         String bodyContentType = getNullCheckedString(message.getStringValue(EmailConstants.MESSAGE_BODY_CONTENT_TYPE));
         String fromAddress = getNullCheckedString(message.getStringValue(EmailConstants.MESSAGE_FROM));
         if (fromAddress == null || fromAddress.isEmpty()) {
+            if (username == null || username.isEmpty()) {
+                throw CommonUtil.getBallerinaError(EmailConstants.ERROR,
+                        "The 'from' field is mandatory when using SMTP client without authentication. " +
+                        "Please specify the 'from' address in the email message.");
+            }
             fromAddress = username;
         }
         String senderAddress = getNullCheckedString(message.getStringValue(EmailConstants.MESSAGE_SENDER));

--- a/native/src/main/java/io/ballerina/stdlib/email/util/SmtpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/email/util/SmtpUtil.java
@@ -89,11 +89,24 @@ public final class SmtpUtil {
      */
     public static Properties getProperties(BMap<BString, Object> smtpConfig, String host)
             throws IOException, GeneralSecurityException {
+        return getProperties(smtpConfig, host, true);
+    }
+
+    /**
+     * Generates the Properties object using the passed BMap.
+     *
+     * @param smtpConfig BMap with the configuration values
+     * @param host Host address of the SMTP server
+     * @param requireAuth Whether authentication is required
+     * @return Properties Set of properties required to connect to an SMTP server
+     */
+    public static Properties getProperties(BMap<BString, Object> smtpConfig, String host, boolean requireAuth)
+            throws IOException, GeneralSecurityException {
         Properties properties = new Properties();
         properties.put(EmailConstants.PROPS_SMTP_HOST, host);
         properties.put(EmailConstants.PROPS_SMTP_PORT, Long.toString(
                 smtpConfig.getIntValue(EmailConstants.PROPS_PORT)));
-        properties.put(EmailConstants.PROPS_SMTP_AUTH, "true");
+        properties.put(EmailConstants.PROPS_SMTP_AUTH, requireAuth ? "true" : "false");
         BString security = smtpConfig.getStringValue(EmailConstants.PROPS_SECURITY);
         if (security != null) {
             String securityType = security.getValue();

--- a/test-utils/src/main/java/io/ballerina/stdlib/email/testutils/SmtpNoAuthEmailSendTest.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/email/testutils/SmtpNoAuthEmailSendTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.email.testutils;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetup;
+import io.ballerina.stdlib.email.util.CommonUtil;
+import io.ballerina.stdlib.email.util.EmailConstants;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import static io.ballerina.stdlib.email.testutils.Assert.assertEquals;
+import static io.ballerina.stdlib.email.testutils.Assert.assertNotNull;
+
+/**
+ * Test class for email send using SMTP without authentication.
+ *
+ * @since 2.13.0
+ */
+public final class SmtpNoAuthEmailSendTest {
+
+    private SmtpNoAuthEmailSendTest() {}
+
+    private static final String EMAIL_USER_ADDRESS = "hascode@localhost";
+    private static final String EMAIL_FROM = "someone@localhost.com";
+    private static final String EMAIL_SUBJECT = "Test E-Mail Without Auth";
+    private static final String EMAIL_TEXT = "This is a test e-mail sent without authentication.";
+    private static final int SMTP_PORT = 3026;
+    private static GreenMail mailServer;
+
+    public static Object startNoAuthSmtpServer() {
+        ServerSetup serverSetup = new ServerSetup(SMTP_PORT, null, ServerSetup.PROTOCOL_SMTP);
+        serverSetup.setServerStartupTimeout(10000);
+        mailServer = new GreenMail(serverSetup);
+        mailServer.start();
+        return null;
+    }
+
+    public static Object stopNoAuthSmtpServer() {
+        if (mailServer != null) {
+            mailServer.stop();
+        }
+        return null;
+    }
+
+    public static Object validateNoAuthEmail() {
+        MimeMessage[] messages = mailServer.getReceivedMessages();
+        assertNotNull(messages);
+        if (messages.length < 1) {
+            return CommonUtil.getBallerinaError(EmailConstants.ERROR,
+                    "No messages received by the SMTP server without authentication");
+        }
+        try {
+            MimeMessage message = messages[0];
+            assertEquals(EMAIL_SUBJECT, message.getSubject());
+            assertNotNull(message.getFrom());
+            assertEquals(EMAIL_FROM, message.getFrom()[0].toString());
+            assertNotNull(message.getRecipients(Message.RecipientType.TO));
+            assertEquals(EMAIL_USER_ADDRESS, message.getRecipients(Message.RecipientType.TO)[0].toString());
+            assertEquals(EMAIL_TEXT, message.getContent().toString().trim());
+        } catch (MessagingException | java.io.IOException e) {
+            return CommonUtil.getBallerinaError(EmailConstants.ERROR,
+                    "Error while validating the email sent without authentication: " + e.getMessage());
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8345

## Examples

Now the SMTP client allows the following:

```ballerina
email:SmtpClient smtpClient = check new ("smtp.email.com");
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [ ] Checked native-image compatibility
