### PR TITLE
Bump BouncyCastle to 1.84 to fix known vulnerabilities

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ javaMailVersion=1.6.2
 greenmailVersion=1.6.15
 mimepullVersion=1.9.11
 javaxActivationVersion=1.1.1
-bouncycastleVersion=1.80
+bouncycastleVersion=1.84
 jacksonDatabindVersion=2.17.2
 
 // Gradle Plugins


### PR DESCRIPTION
## Summary
- `bouncycastleVersion` was still `1.80` in this module, while a security scan flagged `bcprov-jdk18on`/`bcpkix-jdk18on`/`bcpg-jdk18on` 1.80 as vulnerable:
  - CVE-2025-14813 (Critical)
  - CVE-2026-3505 (High)
  - CVE-2026-5588 (Medium)
  - CVE-2026-0636 (Medium)
- Fixed version per the advisories is `1.84`, which is already what every other stdlib module (grpc, http, crypto, mqtt) and `ballerina-lang` use.
- This bumps `bouncycastleVersion` to `1.84` to bring this module in line and resolve the vulnerabilities.

## Test plan
- [ ] CI build passes
- [ ] Existing email module tests pass with the updated BouncyCastle version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Bouncy Castle dependency from `1.80` to `1.84` in `gradle.properties`. This aligns the email module with the version used by other standard library modules and improves dependency maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->