### PR TITLE
Upgrade Gradle to 9.5.1 and Ballerina Gradle plugin to 4.0.0

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -85,8 +92,9 @@ tasks.register('updateTomlFiles') {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ allprojects {
     version = project.version
 
     apply plugin: 'jacoco'
+    jacoco {
+        toolVersion = jacocoVersion
+    }
     apply plugin: 'maven-publish'
 
     repositories {
@@ -105,6 +108,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('email-ballerina:build')
 }

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -42,7 +42,6 @@ tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
 
 test {
     systemProperty "ballerina.offline.flag", "true"
@@ -70,7 +69,7 @@ spotbugsTest {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -54,7 +54,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ version=2.14.1-SNAPSHOT
 
 // Java Dependencies
 ballerinaLangVersion=2201.12.0
+jacocoVersion=0.8.14
 slf4jVersion=1.7.30
 testngVersion=7.6.1
 javaMailVersion=1.6.2
@@ -14,12 +15,12 @@ bouncycastleVersion=1.84
 jacksonDatabindVersion=2.17.2
 
 // Gradle Plugins
-ballerinaGradlePluginVersion=2.3.1
+ballerinaGradlePluginVersion=4.0.0
 checkstylePluginVersion=10.12.0
 downloadPluginVersion=5.4.0
-spotbugPluginVersion=6.0.18
+spotbugPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 
 stdlibTaskVersion=2.11.1
 stdlibMimeVersion=2.12.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -49,7 +49,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'email'
@@ -48,9 +48,9 @@ project(':email-test-utils').projectDir = file('test-utils')
 project(':email-compiler-plugin').projectDir = file('compiler-plugin')
 project(':email-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade the Gradle wrapper to 9.5.1 (with distribution checksum) and the Ballerina Gradle plugin to 4.0.0, needed for Java 21/25 compatibility.
- Fix Gradle 9 breakage: `project.exec` calls now use an injected `ExecOperations`, `com.gradle.enterprise` is migrated to `com.gradle.develocity`, any `task build {}` redefinition is replaced with `tasks.named('build')`, and checkstyle's `build.gradle` drops the deprecated `buildDir` property.

## Test plan
- [x] `./gradlew clean build` passes locally on Gradle 9.5.1 with plugin 4.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Upgrade the Gradle wrapper to 9.5.1 with a distribution checksum.
- Upgrade Ballerina, SpotBugs, release, and JaCoCo tooling.
- Replace deprecated Gradle APIs with `ExecOperations` and `layout.buildDirectory`.
- Update task configuration and ordering for Gradle 9 compatibility.
- Migrate Gradle Enterprise configuration to Develocity.
- Include `greenmail_test.p12` in GraalVM native-image resources.
- Build verification status is not available from the supplied evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->