### PR TITLE
[DO NOT MERGE] Test Java 21/25 compatibility via ballerina-library dev workflows

### DIFF
--- a/.github/workflows/build-timestamped-master.yml
+++ b/.github/workflows/build-timestamped-master.yml
@@ -14,5 +14,5 @@ jobs:
   call_workflow:
     name: Run Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/build-timestamp-master-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/build-timestamp-master-template.yml@dev
     secrets: inherit

--- a/.github/workflows/build-with-bal-test-graalvm.yml
+++ b/.github/workflows/build-with-bal-test-graalvm.yml
@@ -30,7 +30,7 @@ jobs:
     call_stdlib_workflow:
         name: Run StdLib Workflow
         if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'ballerina-platform') }}
-        uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-template.yml@main
+        uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-template.yml@dev
         with:
             lang_tag: ${{ inputs.lang_tag }}
             lang_version: ${{ inputs.lang_version }}

--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -15,7 +15,7 @@ jobs:
   call_workflow:
     name: Run Central Publish Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/central-publish-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/central-publish-template.yml@dev
     secrets: inherit
     with:
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/process-load-test-result.yml
+++ b/.github/workflows/process-load-test-result.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   call_stdlib_process_load_test_results_workflow:
     name: Run StdLib Process Load Test Results Workflow
-    uses: ballerina-platform/ballerina-library/.github/workflows/process-load-test-results-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/process-load-test-results-template.yml@dev
     with:
       results: ${{ toJson(github.event.client_payload.results) }}
     secrets:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,7 +9,7 @@ jobs:
   call_workflow:
     name: Run Release Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/release-package-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/release-package-template.yml@dev
     secrets: inherit
     with:
       package-name: email

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,5 +10,5 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@dev
     secrets: inherit

--- a/.github/workflows/trigger-load-tests.yml
+++ b/.github/workflows/trigger-load-tests.yml
@@ -22,7 +22,7 @@ jobs:
   call_stdlib_trigger_load_test_workflow:
     name: Run StdLib Load Test Workflow
     if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'ballerina-platform') }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/trigger-load-tests-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/trigger-load-tests-template.yml@dev
     with:
       repo_name: 'module-ballerina-email'
       runtime_artifacts_url: 'https://api.github.com/repos/ballerina-platform/module-ballerina-email/actions/artifacts'

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -9,5 +9,5 @@ jobs:
   call_workflow:
     name: Run Trivy Scan Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/trivy-scan-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/trivy-scan-template.yml@dev
     secrets: inherit

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -85,8 +92,9 @@ tasks.register('updateTomlFiles') {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ allprojects {
     version = project.version
 
     apply plugin: 'jacoco'
+    jacoco {
+        toolVersion = jacocoVersion
+    }
     apply plugin: 'maven-publish'
 
     repositories {
@@ -105,6 +108,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('email-ballerina:build')
 }

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -42,7 +42,6 @@ tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
 
 test {
     systemProperty "ballerina.offline.flag", "true"
@@ -70,7 +69,7 @@ spotbugsTest {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -54,7 +54,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ version=2.14.1-SNAPSHOT
 
 // Java Dependencies
 ballerinaLangVersion=2201.12.0
+jacocoVersion=0.8.14
 slf4jVersion=1.7.30
 testngVersion=7.6.1
 javaMailVersion=1.6.2
@@ -14,12 +15,12 @@ bouncycastleVersion=1.84
 jacksonDatabindVersion=2.17.2
 
 // Gradle Plugins
-ballerinaGradlePluginVersion=2.3.1
+ballerinaGradlePluginVersion=4.0.0
 checkstylePluginVersion=10.12.0
 downloadPluginVersion=5.4.0
-spotbugPluginVersion=6.0.18
+spotbugPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 
 stdlibTaskVersion=2.11.1
 stdlibMimeVersion=2.12.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -49,7 +49,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'email'
@@ -48,9 +48,9 @@ project(':email-test-utils').projectDir = file('test-utils')
 project(':email-compiler-plugin').projectDir = file('compiler-plugin')
 project(':email-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary
**DO NOT MERGE — this PR exists only to run CI against the `ballerina-library` `dev` branch workflows for Java 21/25 compatibility testing.**

Combines the gradle upgrade from PR 1 with pointing this repo's `ballerina-library` reusable workflows at `dev` instead of `main`. Close (don't merge) once the `dev` branch changes land upstream in `ballerina-library`'s `main` — PR 1 is the one that should land here.

## Test plan
- [ ] CI passes on the `dev` ballerina-library workflows for Java 21 and Java 25
